### PR TITLE
Fix Publish

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -52,8 +52,6 @@ jobs:
               downloadPath: "$(System.DefaultWorkingDirectory)"
           - script: npm install --build-from-source
             displayName: Install Node Modules
-          - script: npm run compile
-            displayName: Compile and Generate Typings
           - task: Npm@1
             displayName: NPM Release
             inputs:


### PR DESCRIPTION
Apparently the pipeline was still running compile, this PR removes that command as it's been moved to prepublish and should hopefully run automatically (also it's now called transpile)