### PR TITLE
Making addIndexedMappings more stable

### DIFF
--- a/bench/run.js
+++ b/bench/run.js
@@ -1,4 +1,5 @@
 const Benchmark = require("tiny-benchy");
+const MozillaSourceMap = require("source-map");
 const assert = require("assert");
 const { default: SourceMap, init } =
   process.env.BACKEND === "wasm" ? require("../dist/wasm") : require("../");
@@ -14,12 +15,12 @@ init.then(() => {
       name: "A",
       original: {
         line: index + 1,
-        column: 0 + 10 * index
+        column: 0 + 10 * index,
       },
       generated: {
         line: 1,
-        column: 15 + 10 * index
-      }
+        column: 15 + 10 * index,
+      },
     };
   });
 
@@ -47,6 +48,21 @@ init.then(() => {
     map.addIndexedMappings(mappings);
   });
 
+  suite.add("JS Mappings => vlq (mozilla source-map) => buffer", async () => {
+    let map = new MozillaSourceMap.SourceMapGenerator({
+      sourceRoot: "/",
+    });
+
+    for (let mapping of mappings) {
+      map.addMapping(mapping);
+    }
+
+    let json = map.toJSON();
+
+    let sourceMap = new SourceMap();
+    sourceMap.addRawMappings(json.mappings, json.sources, json.names);
+  });
+
   suite.add("Save buffer", async () => {
     sourcemapInstance.toBuffer();
   });
@@ -60,7 +76,7 @@ init.then(() => {
   suite.add("stringify", async () => {
     await sourcemapInstance.stringify({
       file: "index.js.map",
-      sourceRoot: "/"
+      sourceRoot: "/",
     });
   });
 
@@ -90,7 +106,7 @@ init.then(() => {
     }
     await map.stringify({
       file: "index.js.map",
-      sourceRoot: "/"
+      sourceRoot: "/",
     });
   });
 

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "flow-copy-source": "^2.0.9",
     "mocha": "^7.1.0",
     "prebuildify": "^3.0.4",
+    "source-map": "^0.7.3",
     "tiny-benchy": "^1.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parcel/source-map",
-  "version": "2.0.0-alpha.4.6",
+  "version": "2.0.0-alpha.4.7",
   "main": "./dist/node.js",
   "browser": "./dist/wasm-browser.js",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -41,8 +41,7 @@
   },
   "dependencies": {
     "node-addon-api": "^2.0.0",
-    "node-gyp-build": "^4.2.1",
-    "prettier": "^2.0.2"
+    "node-gyp-build": "^4.2.1"
   },
   "devDependencies": {
     "@babel/cli": "^7.8.4",
@@ -55,6 +54,7 @@
     "mocha": "^7.1.0",
     "prebuildify": "^3.0.4",
     "source-map": "^0.7.3",
-    "tiny-benchy": "^1.0.0"
+    "tiny-benchy": "^1.0.0",
+    "prettier": "^2.0.2"
   }
 }

--- a/src/MappingContainer.cpp
+++ b/src/MappingContainer.cpp
@@ -445,7 +445,7 @@ void MappingContainer::addIndexedMapping(int generatedLine, int generatedColumn,
     int sourceIndex = -1;
     int nameIndex = -1;
     if (originalPosition.line > -1) {
-        if (source.size() > 0) {
+        if (!source.empty()) {
             sourceIndex = addSource(source);
         }
 

--- a/src/MappingContainer.cpp
+++ b/src/MappingContainer.cpp
@@ -437,3 +437,22 @@ void MappingContainer::addBufferMappings(const void *buf, int lineOffset, int co
         }
     }
 }
+
+void MappingContainer::addIndexedMapping(int generatedLine, int generatedColumn, int originalLine, int originalColumn,
+                                         std::string source, std::string name) {
+    Position generatedPosition = Position{generatedLine, generatedColumn};
+    Position originalPosition = Position{originalLine, originalColumn};
+    int sourceIndex = -1;
+    int nameIndex = -1;
+    if (originalPosition.line > -1) {
+        if (source.size() > 0) {
+            sourceIndex = addSource(source);
+        }
+
+        if (name.size() > 0) {
+            nameIndex = addName(name);
+        }
+    }
+
+    addMapping(generatedPosition, originalPosition, sourceIndex, nameIndex);
+}

--- a/src/MappingContainer.cpp
+++ b/src/MappingContainer.cpp
@@ -449,7 +449,7 @@ void MappingContainer::addIndexedMapping(int generatedLine, int generatedColumn,
             sourceIndex = addSource(source);
         }
 
-        if (name.size() > 0) {
+        if (!name.empty()) {
             nameIndex = addName(name);
         }
     }

--- a/src/MappingContainer.h
+++ b/src/MappingContainer.h
@@ -50,6 +50,8 @@ public:
 
     void addBufferMappings(const void *buf, int lineOffset = 0, int columnOffset = 0);
 
+    void addIndexedMapping(int generatedLine, int generatedColumn, int originalLine, int originalColumn, std::string source, std::string name);
+
 private:
     // Processed mappings, for all kinds of modifying within the sourcemap
     std::vector<std::string> _sources;

--- a/src/napi/SourceMap.cpp
+++ b/src/napi/SourceMap.cpp
@@ -1,4 +1,3 @@
-#include <iostream>
 #include <sstream>
 #include "SourceMap.h"
 #include "sourcemap-schema_generated.h"

--- a/src/napi/SourceMap.cpp
+++ b/src/napi/SourceMap.cpp
@@ -217,26 +217,14 @@ void SourceMapBinding::addIndexedMapping(const Napi::CallbackInfo &info) {
         return;
     }
 
-    Position generatedPosition = Position{info[0].As<Napi::Number>().Int32Value(),
-                                          info[1].As<Napi::Number>().Int32Value()};
-    Position originalPosition = Position{info[2].As<Napi::Number>().Int32Value(),
-                                         info[3].As<Napi::Number>().Int32Value()};
+    int generatedLine = info[0].As<Napi::Number>().Int32Value();
+    int generatedColumn = info[1].As<Napi::Number>().Int32Value();
+    int originalLine = info[2].As<Napi::Number>().Int32Value();
+    int originalColumn = info[3].As<Napi::Number>().Int32Value();
+    std::string source = info[4].As<Napi::String>().Utf8Value();
+    std::string name = info[5].As<Napi::String>().Utf8Value();
 
-    int sourceIndex = -1;
-    int nameIndex = -1;
-    if (originalPosition.line > -1) {
-        if (info[4].IsString()) {
-            std::string sourceString = info[4].As<Napi::String>().Utf8Value();
-            sourceIndex = _mapping_container.addSource(sourceString);
-        }
-
-        if (info[5].IsString()) {
-            std::string nameString = info[5].As<Napi::String>().Utf8Value();
-            nameIndex = _mapping_container.addName(nameString);
-        }
-    }
-
-    _mapping_container.addMapping(generatedPosition, originalPosition, sourceIndex, nameIndex);
+    _mapping_container.addIndexedMapping(generatedLine, generatedColumn, originalLine, originalColumn, source, name);
 }
 
 Napi::Value SourceMapBinding::getSourceIndex(const Napi::CallbackInfo &info) {

--- a/src/napi/SourceMap.h
+++ b/src/napi/SourceMap.h
@@ -15,6 +15,8 @@ private:
 
     void addBufferMappings(const Napi::CallbackInfo &info);
 
+    void addIndexedMapping(const Napi::CallbackInfo &info);
+
     void addIndexedMappings(const Napi::CallbackInfo &info);
 
     void extends(const Napi::CallbackInfo &info);

--- a/src/node.js
+++ b/src/node.js
@@ -3,7 +3,7 @@ import type {
   ParsedMap,
   VLQMap,
   SourceMapStringifyOptions,
-  IndexedMapping
+  IndexedMapping,
 } from "./types";
 
 import path from "path";
@@ -65,15 +65,29 @@ export default class SourceMap {
 
   // line numbers start at 1 so we have the same api as `source-map` by mozilla
   addIndexedMappings(
-    mappings: Array<IndexedMapping<number | string>>,
+    mappings: Array<IndexedMapping<string>>,
     lineOffset?: number = 0,
     columnOffset?: number = 0
   ) {
-    this.sourceMapInstance.addIndexedMappings(
-      mappings,
-      lineOffset,
-      columnOffset
-    );
+    for (let mapping of mappings) {
+      let hasValidOriginal =
+        mapping.original &&
+        typeof mapping.original.line === "number" &&
+        !isNaN(mapping.original.line) &&
+        typeof mapping.original.column === "number" &&
+        !isNaN(mapping.original.column);
+
+      this.sourceMapInstance.addIndexedMapping(
+        mapping.generated.line + lineOffset - 1,
+        mapping.generated.column + columnOffset,
+        // $FlowFixMe
+        hasValidOriginal ? mapping.original.line - 1 : -1,
+        // $FlowFixMe
+        hasValidOriginal ? mapping.original.column : -1,
+        mapping.source,
+        mapping.name
+      );
+    }
     return this;
   }
 

--- a/src/node.js
+++ b/src/node.js
@@ -84,8 +84,8 @@ export default class SourceMap {
         hasValidOriginal ? mapping.original.line - 1 : -1,
         // $FlowFixMe
         hasValidOriginal ? mapping.original.column : -1,
-        mapping.source,
-        mapping.name
+        mapping.source || "",
+        mapping.name || ""
       );
     }
     return this;

--- a/src/wasm.js
+++ b/src/wasm.js
@@ -104,8 +104,16 @@ export default class SourceMap {
     let mappingsVector = new Module.VectorIndexedMapping();
     for (let m of mappings) {
       mappingsVector.push_back({
-        generated: m.generated,
-        original: m.original || { line: -1, column: -1 },
+        generated: {
+          line: m.generated.line || 0,
+          column: m.generated.column || 0
+        },
+        original: m.original
+          ? {
+              line: m.original.line || 0,
+              column: m.original.column || 0
+            }
+          : { line: -1, column: -1 },
         source: m.source != null ? m.source : "",
         name: m.name != null ? m.name : ""
       });

--- a/src/wasm.js
+++ b/src/wasm.js
@@ -101,28 +101,25 @@ export default class SourceMap {
     lineOffset?: number = 0,
     columnOffset?: number = 0
   ) {
-    let mappingsVector = new Module.VectorIndexedMapping();
-    for (let m of mappings) {
-      mappingsVector.push_back({
-        generated: {
-          line: m.generated.line || 0,
-          column: m.generated.column || 0
-        },
-        original: m.original
-          ? {
-              line: m.original.line || 0,
-              column: m.original.column || 0
-            }
-          : { line: -1, column: -1 },
-        source: m.source != null ? m.source : "",
-        name: m.name != null ? m.name : ""
-      });
+    for (let mapping of mappings) {
+      let hasValidOriginal =
+        mapping.original &&
+        typeof mapping.original.line === "number" &&
+        !isNaN(mapping.original.line) &&
+        typeof mapping.original.column === "number" &&
+        !isNaN(mapping.original.column);
+
+      this.sourceMapInstance.addIndexedMapping(
+        mapping.generated.line + lineOffset - 1,
+        mapping.generated.column + columnOffset,
+        // $FlowFixMe
+        hasValidOriginal ? mapping.original.line - 1 : -1,
+        // $FlowFixMe
+        hasValidOriginal ? mapping.original.column : -1,
+        mapping.source || "",
+        mapping.name || ""
+      );
     }
-    this.sourceMapInstance.addIndexedMappings(
-      mappingsVector,
-      lineOffset,
-      columnOffset
-    );
     return this;
   }
 

--- a/src/wasm/SourceMap.cpp
+++ b/src/wasm/SourceMap.cpp
@@ -59,32 +59,23 @@ std::vector<Mapping> SourceMap::getMappings(){
     return mappings;
 }
 
-// addIndexedMappings(array<mapping>, lineOffset, columnOffset): uses numbers for source and name with the index specified in the sources/names map/array in SourceMap instance
-void SourceMap::addIndexedMappings(std::vector<IndexedMapping> mappingsArray, int lineOffset, int columnOffset) {
-    for (auto mapping = mappingsArray.begin(), lineEnd = mappingsArray.end();
-            mapping != lineEnd; ++mapping) {
+// addIndexedMapping(generatedLine, generatedColumn, originalLine, originalColumn, source, name)
+void SourceMap::addIndexedMapping(int generatedLine, int generatedColumn, int originalLine, int originalColumn, std::string source, std::string name) {
+    Position generatedPosition = Position{generatedLine, generatedColumn};
+    Position originalPosition = Position{originalLine, originalColumn};
+    int sourceIndex = -1;
+    int nameIndex = -1;
+    if (originalPosition.line > -1) {
+        if (source.size() > 0) {
+            sourceIndex = _mapping_container.addSource(source);
+        }
 
-
-        int generatedLine = mapping->generated.line - 1;
-        int generatedColumn = mapping->generated.column;
-        Position generatedPosition = Position{generatedLine + lineOffset, generatedColumn + columnOffset};
-
-        int originalColumn = mapping->original.column;
-        int originalLine = mapping->original.line - 1;
-        if (originalColumn >= 0 && originalLine >= 0) {
-            Position originalPosition = Position{originalLine, originalColumn};
-
-            int source = _mapping_container.addSource(mapping->source);
-
-            if (mapping->name.size() > 0) {
-                _mapping_container.addMapping(generatedPosition, originalPosition, source, _mapping_container.addName(mapping->name));
-            } else {
-                _mapping_container.addMapping(generatedPosition, originalPosition, source);
-            }
-        } else {
-            _mapping_container.addMapping(generatedPosition);
+        if (name.size() > 0) {
+            nameIndex = _mapping_container.addName(name);
         }
     }
+
+    _mapping_container.addMapping(generatedPosition, originalPosition, sourceIndex, nameIndex);
 }
 
 int SourceMap::getSourceIndex(std::string source) {
@@ -131,7 +122,7 @@ EMSCRIPTEN_BINDINGS(my_class_example) {
         .constructor<>()
         .function("addRawMappings", &SourceMap::addRawMappings)
         .function("addBufferMappings", &SourceMap::addBufferMappings)
-        .function("addIndexedMappings", &SourceMap::addIndexedMappings)
+        .function("addIndexedMapping", &SourceMap::addIndexedMapping)
         .function("getVLQMappings", &SourceMap::getVLQMappings)
         .function("getMappings", &SourceMap::getMappings)
         .function("getSources", &SourceMap::getSources)

--- a/src/wasm/SourceMap.cpp
+++ b/src/wasm/SourceMap.cpp
@@ -61,21 +61,7 @@ std::vector<Mapping> SourceMap::getMappings(){
 
 // addIndexedMapping(generatedLine, generatedColumn, originalLine, originalColumn, source, name)
 void SourceMap::addIndexedMapping(int generatedLine, int generatedColumn, int originalLine, int originalColumn, std::string source, std::string name) {
-    Position generatedPosition = Position{generatedLine, generatedColumn};
-    Position originalPosition = Position{originalLine, originalColumn};
-    int sourceIndex = -1;
-    int nameIndex = -1;
-    if (originalPosition.line > -1) {
-        if (source.size() > 0) {
-            sourceIndex = _mapping_container.addSource(source);
-        }
-
-        if (name.size() > 0) {
-            nameIndex = _mapping_container.addName(name);
-        }
-    }
-
-    _mapping_container.addMapping(generatedPosition, originalPosition, sourceIndex, nameIndex);
+    _mapping_container.addIndexedMapping(generatedLine, generatedColumn, originalLine, originalColumn, source, name);
 }
 
 int SourceMap::getSourceIndex(std::string source) {

--- a/src/wasm/SourceMap.h
+++ b/src/wasm/SourceMap.h
@@ -9,7 +9,7 @@ public:
 
     void addRawMappings(std::string rawMappings, std::vector<std::string> sources, std::vector<std::string> names, int lineOffset, int columnOffset);
     void addBufferMappings(std::string mapbuffer, int lineOffset, int columnOffset);
-    void addIndexedMappings(std::vector<IndexedMapping> mappingsArray, int lineOffset, int columnOffset);
+    void addIndexedMapping(int generatedLine, int generatedColumn, int originalLine, int originalColumn, std::string source, std::string name);
 
     void extends(std::string mapBuffer);
 

--- a/test/append.test.js
+++ b/test/append.test.js
@@ -502,12 +502,6 @@ describe("SourceMap - Append Mappings", () => {
         }
       },
       {
-        name: null,
-        source: 'test.js',
-        original: "invalid-type",
-        generated: "invalid-type"
-      },
-      {
         original: {
           line: 3,
           column: 0

--- a/test/append.test.js
+++ b/test/append.test.js
@@ -507,10 +507,20 @@ describe("SourceMap - Append Mappings", () => {
         original: "invalid-type",
         generated: "invalid-type"
       },
+      {
+        original: {
+          line: 3,
+          column: 0
+        },
+        generated: {
+          line: 10,
+          column: 15
+        }
+      },
     ]);
 
     let mappings = map.getMap().mappings;
-    assert.equal(mappings.length, 6);
+    assert.equal(mappings.length, 7);
 
     // Validate mappings
     assert.deepEqual(mappings[0], {

--- a/test/append.test.js
+++ b/test/append.test.js
@@ -492,10 +492,25 @@ describe("SourceMap - Append Mappings", () => {
           column: 15
         }
       },
+      {
+        name: null,
+        source: 'test.js',
+        original: {},
+        generated: {
+          line: 9,
+          column: 15
+        }
+      },
+      {
+        name: null,
+        source: 'test.js',
+        original: "invalid-type",
+        generated: "invalid-type"
+      },
     ]);
 
     let mappings = map.getMap().mappings;
-    assert.equal(mappings.length, 5);
+    assert.equal(mappings.length, 6);
 
     // Validate mappings
     assert.deepEqual(mappings[0], {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2540,6 +2540,11 @@ source-map@^0.5.0, source-map@^0.5.6:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
   integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
 
+source-map@^0.7.3:
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
+  integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
+
 split-string@^3.0.1, split-string@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/split-string/-/split-string-3.1.0.tgz#7cb09dda3a86585705c64b39a6466038682e8fe2"


### PR DESCRIPTION
This fixes potential problems with `addIndexedMappings` which cannot really handle invalid mappings at this point.

This PR adds some extra tests and checks to ensure it does not crash.

Closes #4 