### PR TITLE
Fixup wasm wrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,9 +4,10 @@ node_modules
 .idea
 report.*.json
 
-build
 cmake-*
-prebuilds
-dist
-wasm
 *.o
+build
+dist
+prebuilds
+wasm-node
+wasm-browser

--- a/Makefile
+++ b/Makefile
@@ -4,12 +4,22 @@ CXX=em++
 CPPFLAGS=-Isrc
 CFLAGS=-Oz -flto
 CXXFLAGS=-Oz -flto
-LDFLAGS=-Oz -flto -s ASSERTIONS=0 -flto --llvm-lto 1 -Oz --closure 1 \
-	-s ALLOW_MEMORY_GROWTH=1 -s MODULARIZE=1 -s FILESYSTEM=0 --bind
+LDFLAGS=-s ALLOW_MEMORY_GROWTH=1 -s MODULARIZE=1 -s FILESYSTEM=0 --bind \
+	-Oz -flto -s ASSERTIONS=0 -flto --llvm-lto 1 -Oz --closure 1
 
-wasm/index.js: src/wasm/SourceMap.o src/MappingContainer.o src/MappingLine.o src/Mapping.o
-	mkdir -p wasm
-	$(CXX) -o $@ $? $(LDFLAGS)
+LDFLAGS_BROWSER=-s ENVIRONMENT="web,worker"
+LDFLAGS_NODE=-s ENVIRONMENT="node"
+
+.PHONY:all
+all: wasm-browser/source-map.js wasm-node/source-map.js
+
+wasm-browser/source-map.js: src/wasm/SourceMap.o src/MappingContainer.o src/MappingLine.o src/Mapping.o
+	mkdir -p wasm-browser
+	$(CXX) -o $@ $? $(LDFLAGS) $(LDFLAGS_BROWSER)
+
+wasm-node/source-map.js: src/wasm/SourceMap.o src/MappingContainer.o src/MappingLine.o src/Mapping.o
+	mkdir -p wasm-node
+	$(CXX) -o $@ $? $(LDFLAGS) $(LDFLAGS_NODE)
 
 .PHONY: clean
 clean:

--- a/azure-pipelines-template.yml
+++ b/azure-pipelines-template.yml
@@ -68,9 +68,15 @@ jobs:
           artifactName: prebuilds
           pathtoPublish: "$(System.DefaultWorkingDirectory)/prebuilds"
       - task: PublishBuildArtifacts@1
-        displayName: Publish Wasm Artifacts
+        displayName: Publish wasm-node Artifacts
         condition: and(succeeded(), eq(variables['publish_artifacts'], 'true'), eq('${{ parameters.name }}', 'macOS'))
         inputs:
-          artifactName: wasm
-          pathtoPublish: "$(System.DefaultWorkingDirectory)/wasm-*"
+          artifactName: wasm-node
+          pathtoPublish: "$(System.DefaultWorkingDirectory)/wasm-node"
+      - task: PublishBuildArtifacts@1
+        displayName: Publish wasm-browser Artifacts
+        condition: and(succeeded(), eq(variables['publish_artifacts'], 'true'), eq('${{ parameters.name }}', 'macOS'))
+        inputs:
+          artifactName: wasm-browser
+          pathtoPublish: "$(System.DefaultWorkingDirectory)/wasm-browser"
           

--- a/azure-pipelines-template.yml
+++ b/azure-pipelines-template.yml
@@ -47,14 +47,14 @@ jobs:
           PATH: $(PATH):$(System.DefaultWorkingDirectory)/emsdk/bin:$(System.DefaultWorkingDirectory)/emsdk/upstream/emscripten
         condition: eq('${{ parameters.name }}', 'macOS')
 
-      - script: npm run test-node
+      - script: npm run test:node
         displayName: Run tests (node)
-      - script: npm run benchmark-node
+      - script: npm run benchmark:node
         displayName: Run benchmark (node)
-      - script: npm run test-wasm
+      - script: npm run test:wasm
         displayName: Run tests (wasm)
         condition: eq('${{ parameters.name }}', 'macOS')
-      - script: npm run benchmark-wasm
+      - script: npm run benchmark:wasm
         displayName: Run benchmark (wasm)
         condition: eq('${{ parameters.name }}', 'macOS')
 

--- a/azure-pipelines-template.yml
+++ b/azure-pipelines-template.yml
@@ -68,8 +68,14 @@ jobs:
           artifactName: prebuilds
           pathtoPublish: "$(System.DefaultWorkingDirectory)/prebuilds"
       - task: PublishBuildArtifacts@1
-        displayName: Publish Wasm Artifacts
+        displayName: Publish Wasm Node Artifacts
         condition: and(succeeded(), eq(variables['publish_artifacts'], 'true'), eq('${{ parameters.name }}', 'macOS'))
         inputs:
           artifactName: wasm
-          pathtoPublish: "$(System.DefaultWorkingDirectory)/wasm"
+          pathtoPublish: "$(System.DefaultWorkingDirectory)/wasm-node"
+      - task: PublishBuildArtifacts@1
+        displayName: Publish Wasm Web Artifacts
+        condition: and(succeeded(), eq(variables['publish_artifacts'], 'true'), eq('${{ parameters.name }}', 'macOS'))
+        inputs:
+          artifactName: wasm
+          pathtoPublish: "$(System.DefaultWorkingDirectory)/wasm-browser"

--- a/azure-pipelines-template.yml
+++ b/azure-pipelines-template.yml
@@ -68,14 +68,9 @@ jobs:
           artifactName: prebuilds
           pathtoPublish: "$(System.DefaultWorkingDirectory)/prebuilds"
       - task: PublishBuildArtifacts@1
-        displayName: Publish Wasm Node Artifacts
+        displayName: Publish Wasm Artifacts
         condition: and(succeeded(), eq(variables['publish_artifacts'], 'true'), eq('${{ parameters.name }}', 'macOS'))
         inputs:
           artifactName: wasm
-          pathtoPublish: "$(System.DefaultWorkingDirectory)/wasm-node"
-      - task: PublishBuildArtifacts@1
-        displayName: Publish Wasm Web Artifacts
-        condition: and(succeeded(), eq(variables['publish_artifacts'], 'true'), eq('${{ parameters.name }}', 'macOS'))
-        inputs:
-          artifactName: wasm
-          pathtoPublish: "$(System.DefaultWorkingDirectory)/wasm-browser"
+          pathtoPublish: "$(System.DefaultWorkingDirectory)/wasm-*"
+          

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -46,9 +46,14 @@ jobs:
               artifactName: prebuilds
               downloadPath: "$(System.DefaultWorkingDirectory)"
           - task: DownloadBuildArtifacts@0
-            displayName: Download Wasm Artifacts
+            displayName: Download wasm-node Artifacts
             inputs:
-              artifactName: wasm
+              artifactName: wasm-node
+              downloadPath: "$(System.DefaultWorkingDirectory)"
+          - task: DownloadBuildArtifacts@0
+            displayName: Download wasm-browser Artifacts
+            inputs:
+              artifactName: wasm-browser
               downloadPath: "$(System.DefaultWorkingDirectory)"
           - script: npm install --build-from-source
             displayName: Install Node Modules

--- a/bench/run.js
+++ b/bench/run.js
@@ -1,7 +1,7 @@
 const Benchmark = require("tiny-benchy");
 const assert = require("assert");
 const { default: SourceMap, init } =
-  process.env.BACKEND === "wasm" ? require("../dist/wasm") : require("../");
+  process.env.BACKEND === "wasm" ? require("../dist/wasm-node") : require("../");
 
 const ITERATIONS = 250;
 

--- a/package.json
+++ b/package.json
@@ -2,15 +2,15 @@
   "name": "@parcel/source-map",
   "version": "2.0.0-alpha.4.6",
   "main": "./dist/node.js",
-  "browser": "./dist/wasm.js",
+  "browser": "./dist/wasm-browser.js",
   "license": "MIT",
   "scripts": {
-    "test": "npm run test-node && npm run test-wasm",
-    "test-node": "cross-env BACKEND=node mocha ./test/*.test.js",
-    "test-wasm": "cross-env BACKEND=wasm mocha ./test/*.test.js",
-    "benchmark": "npm run benchmark-node && npm run benchmark-wasm",
-    "benchmark-node": "cross-env BACKEND=node node ./bench/run",
-    "benchmark-wasm": "cross-env BACKEND=wasm node ./bench/run",
+    "test": "npm run test:node && npm run test:wasm",
+    "test:node": "cross-env BACKEND=node mocha ./test/*.test.js",
+    "test:wasm": "cross-env BACKEND=wasm mocha ./test/*.test.js",
+    "benchmark": "npm run benchmark:node && npm run benchmark:wasm",
+    "benchmark:node": "cross-env BACKEND=node node ./bench/run",
+    "benchmark:wasm": "cross-env BACKEND=wasm node ./bench/run",
     "transpile": "babel ./src/*.js --out-dir ./dist && flow-copy-source -v src dist",
     "compile-wasm": "make",
     "lint": "prettier --write src/*.js",
@@ -23,12 +23,13 @@
   },
   "files": [
     "binding.gyp",
-    "wasm",
     "dist",
     "package.json",
     "prebuilds",
     "README.md",
-    "src"
+    "src",
+    "wasm-browser",
+    "wasm-node"
   ],
   "binary": {
     "napi_versions": [

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "benchmark-wasm": "cross-env BACKEND=wasm node ./bench/run",
     "transpile": "babel ./src/*.js --out-dir ./dist && flow-copy-source -v src dist",
     "compile-wasm": "make",
+    "lint": "prettier --write src/*.js",
     "prebuild": "prebuildify --napi --strip --tag-libc",
     "build:dev": "node-gyp rebuild --debug",
     "rebuild": "rm -rf build && yarn build:dev",
@@ -34,9 +35,13 @@
       3
     ]
   },
+  "engines": {
+    "node": ">= 10"
+  },
   "dependencies": {
     "node-addon-api": "^2.0.0",
-    "node-gyp-build": "^4.2.1"
+    "node-gyp-build": "^4.2.1",
+    "prettier": "^2.0.2"
   },
   "devDependencies": {
     "@babel/cli": "^7.8.4",

--- a/src/node.js
+++ b/src/node.js
@@ -3,7 +3,7 @@ import type {
   ParsedMap,
   VLQMap,
   SourceMapStringifyOptions,
-  IndexedMapping
+  IndexedMapping,
 } from "./types";
 
 import path from "path";

--- a/src/types.js
+++ b/src/types.js
@@ -1,7 +1,7 @@
 // @flow
 export type MappingPosition = {|
   line: number,
-  column: number
+  column: number,
 |};
 
 export type IndexedMapping<T> = {
@@ -15,7 +15,7 @@ export type IndexedMapping<T> = {
 export type ParsedMap = {|
   sources: Array<string>,
   names: Array<string>,
-  mappings: Array<IndexedMapping<number>>
+  mappings: Array<IndexedMapping<number>>,
 |};
 
 export type VLQMap = {

--- a/src/utils.js
+++ b/src/utils.js
@@ -18,7 +18,7 @@ export async function partialVlqMapToSourceMap(
     inlineSources,
     rootDir,
     inlineMap,
-    format = "string"
+    format = "string",
   }: SourceMapStringifyOptions
 ) {
   map.version = 3;
@@ -27,7 +27,7 @@ export async function partialVlqMapToSourceMap(
 
   if (inlineSources && fs) {
     map.sourcesContent = await Promise.all(
-      map.sources.map(async sourceName => {
+      map.sources.map(async (sourceName) => {
         try {
           return await fs.readFile(
             path.join(rootDir || "", sourceName),

--- a/src/wasm-browser.js
+++ b/src/wasm-browser.js
@@ -1,0 +1,5 @@
+import SourceMap, { init as _init } from "./wasm.js";
+import RawModule from "../wasm-browser/source-map.js";
+
+export default SourceMap;
+export const init = _init(RawModule);

--- a/src/wasm-node.js
+++ b/src/wasm-node.js
@@ -1,0 +1,5 @@
+import SourceMap, { init as _init } from "./wasm.js";
+import RawModule from "../wasm-node/source-map.js";
+
+export default SourceMap;
+export const init = _init(RawModule);

--- a/src/wasm.js
+++ b/src/wasm.js
@@ -9,7 +9,6 @@ import type {
 import path from "path";
 import { generateInlineMap, partialVlqMapToSourceMap } from "./utils";
 
-import RawModule from "../wasm/index.js";
 let Module;
 
 function arrayFromEmbind(from, mutate): any {
@@ -184,9 +183,11 @@ export default class SourceMap {
   }
 }
 
-export const init = new Promise<void>((res) =>
-  RawModule().then((v) => {
-    Module = v;
-    res();
-  })
-);
+export function init(RawModule) {
+  return new Promise<void>((res) =>
+    RawModule().then((v) => {
+      Module = v;
+      res();
+    })
+  );
+}

--- a/src/wasm.js
+++ b/src/wasm.js
@@ -3,7 +3,7 @@ import type {
   ParsedMap,
   VLQMap,
   SourceMapStringifyOptions,
-  IndexedMapping
+  IndexedMapping,
 } from "./types";
 
 import path from "path";
@@ -107,7 +107,7 @@ export default class SourceMap {
         generated: m.generated,
         original: m.original || { line: -1, column: -1 },
         source: m.source != null ? m.source : "",
-        name: m.name != null ? m.name : ""
+        name: m.name != null ? m.name : "",
       });
     }
     this.sourceMapInstance.addIndexedMappings(
@@ -163,7 +163,7 @@ export default class SourceMap {
     return {
       mappings,
       sources: arrayFromEmbind(this.sourceMapInstance.getSources()),
-      names: arrayFromEmbind(this.sourceMapInstance.getNames())
+      names: arrayFromEmbind(this.sourceMapInstance.getNames()),
     };
   }
 
@@ -175,7 +175,7 @@ export default class SourceMap {
     return {
       mappings: this.sourceMapInstance.getVLQMappings(),
       sources: arrayFromEmbind(this.sourceMapInstance.getSources()),
-      names: arrayFromEmbind(this.sourceMapInstance.getNames())
+      names: arrayFromEmbind(this.sourceMapInstance.getNames()),
     };
   }
 
@@ -184,8 +184,8 @@ export default class SourceMap {
   }
 }
 
-export const init = new Promise<void>(res =>
-  RawModule().then(v => {
+export const init = new Promise<void>((res) =>
+  RawModule().then((v) => {
     Module = v;
     res();
   })

--- a/src/wasm/SourceMap.cpp
+++ b/src/wasm/SourceMap.cpp
@@ -37,7 +37,7 @@ std::vector<std::string> SourceMap::getNames(){
 
 emscripten::val SourceMap::toBuffer() {
     auto builder = _mapping_container.toBuffer();
-    return emscripten::val(emscripten::typed_memory_view(builder.GetSize(), builder.GetBufferPointer()));
+    return emscripten::val(emscripten::memory_view<uint8_t>(builder.GetSize(), builder.GetBufferPointer()));
 }
 
 std::vector<Mapping> SourceMap::getMappings(){

--- a/test/index.js
+++ b/test/index.js
@@ -1,7 +1,7 @@
 if (!process.env.BACKEND || process.env.BACKEND === "node") {
 	module.exports = require("../dist/node");
 } else if (process.env.BACKEND === "wasm") {
-	module.exports = require("../dist/wasm");
+	module.exports = require("../dist/wasm-node");
 }
 
 beforeEach(async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2264,6 +2264,11 @@ prebuildify@^3.0.4:
     tar-fs "^1.16.2"
     xtend "^4.0.1"
 
+prettier@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.0.2.tgz#1ba8f3eb92231e769b7fcd7cb73ae1b6b74ade08"
+  integrity sha512-5xJQIPT8BraI7ZnaDwSbu5zLrB6vvi8hVV58yHQ+QK64qrY40dULy0HSRlQ2/2IdzeBpjhDkqdcFBnFeDEMVdg==
+
 private@^0.1.8:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"


### PR DESCRIPTION
Previously, the js wrapper from emscripten tried to load the wasm module from
`http://localhost:5000//home/niklas/Desktop/parcel-repl/node_modules/@parcel/source-map/wasm/index.wasm` (when inside a worker).

This makes the REPL work again (though I havent verified if the sourcemap is actually valid).

Todo: update publishing