### PR TITLE
Inline sources from outside the rootDir regardless of inline settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ You can create a sourcemap from another sourcemap or by creating it one mapping 
 
 #### Creating from existing sourcemap
 
-To create a sourcemap from an existing sourcemap you have to ensure it is a JS Object first by asking for the object version from whichever transpiler you're running or by parsing the serialised map using `JSON.parse`.
+To create a sourcemap from an existing sourcemap you have to ensure it is a JS Object first by asking for the object version from whichever transpiler you're running or by parsing the serialised map using `JSON.parse` or any other JSON parser.
 
-After this you can call the function `addRawMappings(mappings, sources, names, lineOffset, columnOffset)` this function takes in the parameters `mappings`, `sources`, `names`, `lineOffset` and `columnOffset`. These correspond to the mappings, sources and names fields in the sourcemap object. The line and column offset are optional parameters used for offsetting the generated line and column. (this can be used when post-processing or wrapping the code linked to the sourcemap, in Parcel this is used when combining maps).
+After this you can call the function `addRawMappings(map, lineOffset, columnOffset)` this function takes in the parameters `map`, `lineOffset` and `columnOffset`. The map argument corresponds to the sourcemap object. The line and column offset are optional parameters used for offsetting the generated line and column. (this can be used when post-processing or wrapping the code linked to the sourcemap, in Parcel this is used when combining maps).
 
 Example:
 
@@ -34,7 +34,7 @@ const RAW_SOURCEMAP = {
 };
 
 let sourcemap = new SourceMap();
-sourcemap.addRawMappings(RAW_SOURCEMAP.mappings, RAW_SOURCEMAP.sources, RAW_SOURCEMAP.names);
+sourcemap.addRawMappings(RAW_SOURCEMAP);
 
 // This function removes the underlying references in the native code
 sourcemap.delete();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parcel/source-map",
-  "version": "2.0.0-alpha.4.11",
+  "version": "2.0.0-alpha.4.12",
   "main": "./dist/node.js",
   "browser": "./dist/wasm-browser.js",
   "license": "MIT",
@@ -63,6 +63,7 @@
     "cross-env": "^7.0.2",
     "flow-bin": "^0.123.0",
     "flow-copy-source": "^2.0.9",
+    "fs-extra": "^9.0.1",
     "husky": "^4.2.5",
     "lint-staged": "^10.2.9",
     "mocha": "^7.1.2",

--- a/src/SourceMap.js
+++ b/src/SourceMap.js
@@ -175,10 +175,22 @@ export default class SourceMap {
     return this.sourceMapInstance.getSource(index);
   }
 
+  /**
+   * Set the sourceContent for a certain file
+   * this is optional and is only recommended for files that we cannot read in at the end when we serialise the sourcemap
+   *
+   * @param {string} sourceName the path of the sourceFile
+   * @param {string} sourceContent the content of the sourceFile
+   */
   setSourceContent(sourceName: string, sourceContent: string): void {
     return this.sourceMapInstance.setSourceContent(sourceName, sourceContent);
   }
 
+  /**
+   * Get the content of a source file if it is inlined as part of the source-map
+   *
+   * @param {string} sourceName
+   */
   getSourceContent(sourceName: string): string {
     return this.sourceMapInstance.getSourceContent(sourceName);
   }

--- a/src/utils.js
+++ b/src/utils.js
@@ -53,6 +53,8 @@ export async function partialVlqMapToSourceMap(
     resultMap.sourcesContent = await Promise.all(
       resultMap.sourcesContent.map(async (content, index): Promise<string | null> => {
         let sourceName = map.sources[index];
+        // If sourceName starts with `..` it is outside rootDir, in this case we likely cannot access this file from the browser or packaged node_module
+        // Because of this we have to include the sourceContent to ensure you can always see the sourcecontent for each mapping.
         if (!content && (inlineSources || sourceName.startsWith('..'))) {
           try {
             return await fs.readFile(path.resolve(root, sourceName), 'utf-8');

--- a/src/utils.js
+++ b/src/utils.js
@@ -49,17 +49,17 @@ export async function partialVlqMapToSourceMap(
     resultMap.sourcesContent.push(...new Array(resultMap.sources.length - resultMap.sourcesContent.length).fill(null));
   }
 
-  if (inlineSources && fs) {
+  if (fs) {
     resultMap.sourcesContent = await Promise.all(
       resultMap.sourcesContent.map(async (content, index): Promise<string | null> => {
-        if (content) {
-          let sourceName = map.sources[index];
+        let sourceName = map.sources[index];
+        if (!content && (inlineSources || sourceName.startsWith('..'))) {
           try {
             return await fs.readFile(path.resolve(root, sourceName), 'utf-8');
           } catch (e) {}
         }
 
-        return null;
+        return content;
       })
     );
   }

--- a/test/inline-source.test.js
+++ b/test/inline-source.test.js
@@ -1,0 +1,133 @@
+const assert = require('assert');
+const fs = require('fs-extra');
+const path = require('path');
+const SourceMap = require('.').default;
+
+const SIMPLE_SOURCE_MAP = {
+  version: 3,
+  file: 'bundle.js',
+  sources: ['../a.js', 'b.js'],
+  names: [],
+  mappings: 'AAAA;AAAA,EAAA,OAAO,CAAC,GAAR,CAAY,aAAZ,CAAA,CAAA;AAAA',
+};
+
+const ROOT_DIR = path.join(__dirname, 'integration/sub-folder');
+
+describe('SourceMap - Inline Sources', () => {
+  it('Should be able to inline sources', async () => {
+    let map = new SourceMap();
+    map.addRawMappings({
+      mappings: SIMPLE_SOURCE_MAP.mappings,
+      sources: SIMPLE_SOURCE_MAP.sources,
+      names: SIMPLE_SOURCE_MAP.names,
+    });
+
+    let stringifiedMap = await map.stringify({
+      file: 'bundle.js.map',
+      sourceRoot: '/',
+      format: 'object',
+      fs,
+      rootDir: ROOT_DIR,
+      inlineSources: true,
+    });
+
+    assert.deepEqual(stringifiedMap, {
+      mappings: 'AAAA;AAAA,EAAA,OAAO,CAAC,GAAR,CAAY,aAAZ,CAAA,CAAA;AAAA',
+      sources: ['../a.js', './b.js'],
+      sourcesContent: [
+        "module.exports = () => {\n  return 'a';\n};\n",
+        "module.exports = () => {\n  return 'b';\n};\n",
+      ],
+      names: [],
+      version: 3,
+      file: 'bundle.js.map',
+      sourceRoot: '/',
+    });
+  });
+
+  it('Should always inline sources outside the root', async () => {
+    let map = new SourceMap();
+    map.addRawMappings({
+      mappings: SIMPLE_SOURCE_MAP.mappings,
+      sources: SIMPLE_SOURCE_MAP.sources,
+      names: SIMPLE_SOURCE_MAP.names,
+    });
+
+    let stringifiedMap = await map.stringify({
+      file: 'bundle.js.map',
+      sourceRoot: '/',
+      format: 'object',
+      fs,
+      rootDir: ROOT_DIR,
+      inlineSources: false,
+    });
+
+    assert.deepEqual(stringifiedMap, {
+      mappings: 'AAAA;AAAA,EAAA,OAAO,CAAC,GAAR,CAAY,aAAZ,CAAA,CAAA;AAAA',
+      sources: ['../a.js', './b.js'],
+      sourcesContent: ["module.exports = () => {\n  return 'a';\n};\n", null],
+      names: [],
+      version: 3,
+      file: 'bundle.js.map',
+      sourceRoot: '/',
+    });
+  });
+
+  it('Should not overwrite existing sourceContent when inlining is true', async () => {
+    let map = new SourceMap();
+    map.addRawMappings({
+      mappings: SIMPLE_SOURCE_MAP.mappings,
+      sources: SIMPLE_SOURCE_MAP.sources,
+      names: SIMPLE_SOURCE_MAP.names,
+      sourcesContent: [null, 'b-content'],
+    });
+
+    let stringifiedMap = await map.stringify({
+      file: 'bundle.js.map',
+      sourceRoot: '/',
+      format: 'object',
+      fs,
+      rootDir: ROOT_DIR,
+      inlineSources: true,
+    });
+
+    assert.deepEqual(stringifiedMap, {
+      mappings: 'AAAA;AAAA,EAAA,OAAO,CAAC,GAAR,CAAY,aAAZ,CAAA,CAAA;AAAA',
+      sources: ['../a.js', './b.js'],
+      sourcesContent: ["module.exports = () => {\n  return 'a';\n};\n", 'b-content'],
+      names: [],
+      version: 3,
+      file: 'bundle.js.map',
+      sourceRoot: '/',
+    });
+  });
+
+  it('Should not overwrite existing sourceContent when inlining is false', async () => {
+    let map = new SourceMap();
+    map.addRawMappings({
+      mappings: SIMPLE_SOURCE_MAP.mappings,
+      sources: SIMPLE_SOURCE_MAP.sources,
+      names: SIMPLE_SOURCE_MAP.names,
+      sourcesContent: ['a-content', 'b-content'],
+    });
+
+    let stringifiedMap = await map.stringify({
+      file: 'bundle.js.map',
+      sourceRoot: '/',
+      format: 'object',
+      fs,
+      rootDir: ROOT_DIR,
+      inlineSources: false,
+    });
+
+    assert.deepEqual(stringifiedMap, {
+      mappings: 'AAAA;AAAA,EAAA,OAAO,CAAC,GAAR,CAAY,aAAZ,CAAA,CAAA;AAAA',
+      sources: ['../a.js', './b.js'],
+      sourcesContent: ['a-content', 'b-content'],
+      names: [],
+      version: 3,
+      file: 'bundle.js.map',
+      sourceRoot: '/',
+    });
+  });
+});

--- a/test/inline-source.test.js
+++ b/test/inline-source.test.js
@@ -12,6 +12,8 @@ const SIMPLE_SOURCE_MAP = {
 };
 
 const ROOT_DIR = path.join(__dirname, 'integration/sub-folder');
+const fileOneContent = fs.readFileSync(path.join(ROOT_DIR, SIMPLE_SOURCE_MAP.sources[0]), 'utf-8');
+const fileTwoContent = fs.readFileSync(path.join(ROOT_DIR, SIMPLE_SOURCE_MAP.sources[1]), 'utf-8');
 
 describe('SourceMap - Inline Sources', () => {
   it('Should be able to inline sources', async () => {
@@ -34,10 +36,7 @@ describe('SourceMap - Inline Sources', () => {
     assert.deepEqual(stringifiedMap, {
       mappings: 'AAAA;AAAA,EAAA,OAAO,CAAC,GAAR,CAAY,aAAZ,CAAA,CAAA;AAAA',
       sources: ['../a.js', './b.js'],
-      sourcesContent: [
-        "module.exports = () => {\n  return 'a';\n};\n",
-        "module.exports = () => {\n  return 'b';\n};\n",
-      ],
+      sourcesContent: [fileOneContent, fileTwoContent],
       names: [],
       version: 3,
       file: 'bundle.js.map',
@@ -65,7 +64,7 @@ describe('SourceMap - Inline Sources', () => {
     assert.deepEqual(stringifiedMap, {
       mappings: 'AAAA;AAAA,EAAA,OAAO,CAAC,GAAR,CAAY,aAAZ,CAAA,CAAA;AAAA',
       sources: ['../a.js', './b.js'],
-      sourcesContent: ["module.exports = () => {\n  return 'a';\n};\n", null],
+      sourcesContent: [fileOneContent, null],
       names: [],
       version: 3,
       file: 'bundle.js.map',
@@ -94,7 +93,7 @@ describe('SourceMap - Inline Sources', () => {
     assert.deepEqual(stringifiedMap, {
       mappings: 'AAAA;AAAA,EAAA,OAAO,CAAC,GAAR,CAAY,aAAZ,CAAA,CAAA;AAAA',
       sources: ['../a.js', './b.js'],
-      sourcesContent: ["module.exports = () => {\n  return 'a';\n};\n", 'b-content'],
+      sourcesContent: [fileOneContent, 'b-content'],
       names: [],
       version: 3,
       file: 'bundle.js.map',

--- a/test/integration/a.js
+++ b/test/integration/a.js
@@ -1,0 +1,3 @@
+module.exports = () => {
+  return 'a';
+};

--- a/test/integration/sub-folder/b.js
+++ b/test/integration/sub-folder/b.js
@@ -1,0 +1,3 @@
+module.exports = () => {
+  return 'b';
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -926,6 +926,11 @@ async-each@^1.0.1:
   resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.3.tgz#b727dbf87d7651602f06f4d4ac387f47d91b0cbf"
   integrity sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==
 
+at-least-node@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/at-least-node/-/at-least-node-1.0.0.tgz#602cd4b46e844ad4effc92a8011a3c46e0238dc2"
+  integrity sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==
+
 atob@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
@@ -1635,6 +1640,16 @@ fs-extra@^8.1.0:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
+fs-extra@^9.0.1:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.0.1.tgz#910da0062437ba4c39fedd863f1675ccfefcb9fc"
+  integrity sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==
+  dependencies:
+    at-least-node "^1.0.0"
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^1.0.0"
+
 fs-readdir-recursive@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz#e32fc030a2ccee44a6b5371308da54be0b397d27"
@@ -2096,6 +2111,15 @@ jsonfile@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
   integrity sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=
+  optionalDependencies:
+    graceful-fs "^4.1.6"
+
+jsonfile@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-6.0.1.tgz#98966cba214378c8c84b82e085907b40bf614179"
+  integrity sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==
+  dependencies:
+    universalify "^1.0.0"
   optionalDependencies:
     graceful-fs "^4.1.6"
 
@@ -3296,6 +3320,11 @@ universalify@^0.1.0:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
   integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
+
+universalify@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-1.0.0.tgz#b61a1da173e8435b2fe3c67d29b9adf8594bd16d"
+  integrity sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==
 
 unset-value@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
This PR implements a feature discussed in the Parcel repo discussions for what to do with assets outside the rootDir, this PR inlines these sources regardless of inlining settings. This is the only way to access these assets without introducing a `directory traversal` vulnerability into our dev-server.

This PR also updates documentation for code introduced earlier, the README and comments needed a small update due to this.

Besides all this I also bumped the version so we can release this. So we can hopefully release a stable source-map package api to the Parcel Beta.
I checked and this should not impact any current alphas or nightly releases as the alpha basically downloads all nightly versions... and the nightly releases use fixed versioning anyway. I don't even think the alpha even uses this library and probably already is broken if this is the case...

Related to: https://github.com/parcel-bundler/parcel/discussions/4706
