### PR TITLE
Fixes and improvements to sourcepath handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "prebuild": "prebuildify -t 10.20.1 --napi --strip --tag-libc",
     "build:dev": "node-gyp rebuild --debug",
     "rebuild": "rm -rf build && yarn build:dev",
+    "rebuild-all": "yarn transpile && yarn compile-wasm && yarn rebuild",
     "install": "node-gyp-build",
     "prepublish": "npm run transpile",
     "lint": "prettier --write bench/run.js src/*.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parcel/source-map",
-  "version": "2.0.0-alpha.4.13",
+  "version": "2.0.0-alpha.4.14",
   "main": "./dist/node.js",
   "browser": "./dist/wasm-browser.js",
   "license": "MIT",

--- a/src/SourceMap.js
+++ b/src/SourceMap.js
@@ -2,7 +2,7 @@
 import type { ParsedMap, VLQMap, SourceMapStringifyOptions, IndexedMapping } from './types';
 
 import path from 'path';
-import { generateInlineMap, partialVlqMapToSourceMap } from './utils';
+import { generateInlineMap, partialVlqMapToSourceMap, normalisePath } from './utils';
 
 export default class SourceMap {
   /**
@@ -45,7 +45,7 @@ export default class SourceMap {
     }
     this.sourceMapInstance.addRawMappings(
       mappings,
-      sources,
+      sources.map((source) => (source ? normalisePath(source) : '')),
       sourcesContent.map((content) => (content ? content : '')),
       names,
       lineOffset,
@@ -90,7 +90,7 @@ export default class SourceMap {
       hasValidOriginal ? mapping.original.line - 1 : -1,
       // $FlowFixMe
       hasValidOriginal ? mapping.original.column : -1,
-      mapping.source || '',
+      mapping.source ? normalisePath(mapping.source) : '',
       mapping.name || ''
     );
   }
@@ -144,7 +144,7 @@ export default class SourceMap {
    * @returns the index of the added source filepath in the sources array
    */
   addSource(source: string): number {
-    return this.sourceMapInstance.addSource(source);
+    return this.sourceMapInstance.addSource(normalisePath(source));
   }
 
   /**
@@ -163,7 +163,7 @@ export default class SourceMap {
    * @param source the filepath of the source file
    */
   getSourceIndex(source: string): number {
-    return this.sourceMapInstance.getSourceIndex(source);
+    return this.sourceMapInstance.getSourceIndex(normalisePath(source));
   }
 
   /**
@@ -183,7 +183,7 @@ export default class SourceMap {
    * @param sourceContent the content of the sourceFile
    */
   setSourceContent(sourceName: string, sourceContent: string): void {
-    return this.sourceMapInstance.setSourceContent(sourceName, sourceContent);
+    return this.sourceMapInstance.setSourceContent(normalisePath(sourceName), sourceContent);
   }
 
   /**
@@ -192,7 +192,7 @@ export default class SourceMap {
    * @param sourceName filename
    */
   getSourceContent(sourceName: string): string {
-    return this.sourceMapInstance.getSourceContent(sourceName);
+    return this.sourceMapInstance.getSourceContent(normalisePath(sourceName));
   }
 
   /**

--- a/src/SourceMap.js
+++ b/src/SourceMap.js
@@ -1,8 +1,8 @@
 // @flow
-import type { ParsedMap, VLQMap, SourceMapStringifyOptions, IndexedMapping } from './types';
+import type { ParsedMap, VLQMap, SourceMapStringifyOptions, IndexedMapping, GenerateEmptyMapOptions } from './types';
 
 import path from 'path';
-import { generateInlineMap, partialVlqMapToSourceMap, normalisePath } from './utils';
+import { generateInlineMap, partialVlqMapToSourceMap, relatifyPath, normalizePath } from './utils';
 
 export default class SourceMap {
   /**
@@ -11,13 +11,32 @@ export default class SourceMap {
   sourceMapInstance: any;
 
   /**
+   * @private
+   */
+  projectRoot: string;
+
+  /**
+   * Construct a SourceMap instance
+   *
+   * @param projectRoot root directory of the project, this is to ensure all source paths are relative to this path
+   */
+  constructor(projectRoot: string = '/') {
+    this.projectRoot = normalizePath(projectRoot);
+  }
+
+  /**
    * Generates an empty map from the provided fileName and sourceContent
    *
    * @param sourceName path of the source file
    * @param sourceContent content of the source file
    * @param lineOffset an offset that gets added to the sourceLine index of each mapping
    */
-  static generateEmptyMap(sourceName: string, sourceContent: string, lineOffset: number = 0): SourceMap {
+  static generateEmptyMap({
+    projectRoot,
+    sourceName,
+    sourceContent,
+    lineOffset = 0,
+  }: GenerateEmptyMapOptions): SourceMap {
     throw new Error('SourceMap.generateEmptyMap() must be implemented when extending SourceMap');
   }
 
@@ -37,21 +56,7 @@ export default class SourceMap {
    * Appends raw VLQ mappings to the sourcemaps
    */
   addRawMappings(map: VLQMap, lineOffset: number = 0, columnOffset: number = 0): SourceMap {
-    let { sourcesContent, sources = [], mappings, names = [] } = map;
-    if (!sourcesContent) {
-      sourcesContent = sources.map(() => '');
-    } else {
-      sourcesContent = sourcesContent.map((content) => (content ? content : ''));
-    }
-    this.sourceMapInstance.addRawMappings(
-      mappings,
-      sources.map((source) => (source ? normalisePath(source) : '')),
-      sourcesContent.map((content) => (content ? content : '')),
-      names,
-      lineOffset,
-      columnOffset
-    );
-    return this;
+    throw new Error('SourceMap.addRawMappings() must be implemented when extending SourceMap');
   }
 
   /**
@@ -90,7 +95,7 @@ export default class SourceMap {
       hasValidOriginal ? mapping.original.line - 1 : -1,
       // $FlowFixMe
       hasValidOriginal ? mapping.original.column : -1,
-      mapping.source ? normalisePath(mapping.source) : '',
+      mapping.source ? relatifyPath(mapping.source, this.projectRoot) : '',
       mapping.name || ''
     );
   }
@@ -144,7 +149,7 @@ export default class SourceMap {
    * @returns the index of the added source filepath in the sources array
    */
   addSource(source: string): number {
-    return this.sourceMapInstance.addSource(normalisePath(source));
+    return this.sourceMapInstance.addSource(relatifyPath(source, this.projectRoot));
   }
 
   /**
@@ -163,7 +168,7 @@ export default class SourceMap {
    * @param source the filepath of the source file
    */
   getSourceIndex(source: string): number {
-    return this.sourceMapInstance.getSourceIndex(normalisePath(source));
+    return this.sourceMapInstance.getSourceIndex(relatifyPath(source, this.projectRoot));
   }
 
   /**
@@ -183,7 +188,7 @@ export default class SourceMap {
    * @param sourceContent the content of the sourceFile
    */
   setSourceContent(sourceName: string, sourceContent: string): void {
-    return this.sourceMapInstance.setSourceContent(normalisePath(sourceName), sourceContent);
+    return this.sourceMapInstance.setSourceContent(relatifyPath(sourceName, this.projectRoot), sourceContent);
   }
 
   /**
@@ -192,7 +197,7 @@ export default class SourceMap {
    * @param sourceName filename
    */
   getSourceContent(sourceName: string): string {
-    return this.sourceMapInstance.getSourceContent(normalisePath(sourceName));
+    return this.sourceMapInstance.getSourceContent(relatifyPath(sourceName, this.projectRoot));
   }
 
   /**
@@ -299,6 +304,9 @@ export default class SourceMap {
    * @param options options used for formatting the serialised map
    */
   async stringify(options: SourceMapStringifyOptions): Promise<string | VLQMap> {
-    return partialVlqMapToSourceMap(this.toVLQ(), options);
+    return partialVlqMapToSourceMap(this.toVLQ(), {
+      ...options,
+      rootDir: this.projectRoot || options.rootDir,
+    });
   }
 }

--- a/src/types.js
+++ b/src/types.js
@@ -33,9 +33,20 @@ export type VLQMap = {
 export type SourceMapStringifyOptions = {
   file?: string,
   sourceRoot?: string,
-  rootDir?: string,
   inlineSources?: boolean,
   fs?: { readFile(path: string, encoding: string): Promise<string>, ... },
   format?: 'inline' | 'string' | 'object',
+  /**
+   * @private
+   */
+  rootDir?: string,
+  ...
+};
+
+export type GenerateEmptyMapOptions = {
+  projectRoot: string,
+  sourceName: string,
+  sourceContent: string,
+  lineOffset?: number,
   ...
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -7,7 +7,7 @@ export function generateInlineMap(map: string): string {
   return `data:application/json;charset=utf-8;base64,${Buffer.from(map).toString('base64')}`;
 }
 
-export function normalisePath(filepath: string): string {
+export function normalizePath(filepath: string): string {
   filepath = filepath.replace(/\\/g, '/');
 
   // Prefix relative paths with ./ as it makes it more clear and probably prevents issues
@@ -18,13 +18,13 @@ export function normalisePath(filepath: string): string {
   return filepath;
 }
 
-function relatifyPath(filepath: string, rootDir: string): string {
+export function relatifyPath(filepath: string, rootDir: string): string {
   // Sourcemaps are made for web, so replace backslashes with regular slashes
-  filepath = normalisePath(filepath);
+  filepath = normalizePath(filepath);
 
   // Make root paths relative to the rootDir
   if (filepath[0] === '/') {
-    filepath = normalisePath(path.relative(rootDir, filepath));
+    filepath = normalizePath(path.relative(rootDir, filepath));
   }
 
   return filepath;
@@ -34,7 +34,6 @@ export async function partialVlqMapToSourceMap(
   map: VLQMap,
   { fs, file, sourceRoot, inlineSources, rootDir, format = 'string' }: SourceMapStringifyOptions
 ): Promise<VLQMap | string> {
-  let root = normalisePath(rootDir || '/');
   let resultMap = {
     ...map,
     sourcesContent: map.sourcesContent ? map.sourcesContent.map((content) => (content ? content : null)) : [],
@@ -42,10 +41,6 @@ export async function partialVlqMapToSourceMap(
     file,
     sourceRoot,
   };
-
-  resultMap.sources = resultMap.sources.map((sourceFilePath) => {
-    return relatifyPath(sourceFilePath, root);
-  });
 
   if (resultMap.sourcesContent.length < resultMap.sources.length) {
     resultMap.sourcesContent.push(...new Array(resultMap.sources.length - resultMap.sourcesContent.length).fill(null));
@@ -59,7 +54,7 @@ export async function partialVlqMapToSourceMap(
         // Because of this we have to include the sourceContent to ensure you can always see the sourcecontent for each mapping.
         if (!content && (inlineSources || sourceName.startsWith('..'))) {
           try {
-            return await fs.readFile(path.resolve(root, sourceName), 'utf-8');
+            return await fs.readFile(path.resolve(rootDir || '/', sourceName), 'utf-8');
           } catch (e) {}
         }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -7,8 +7,15 @@ export function generateInlineMap(map: string): string {
   return `data:application/json;charset=utf-8;base64,${Buffer.from(map).toString('base64')}`;
 }
 
-function normalisePath(filepath: string): string {
-  return filepath.replace(/\\/g, '/');
+export function normalisePath(filepath: string): string {
+  filepath = filepath.replace(/\\/g, '/');
+
+  // Prefix relative paths with ./ as it makes it more clear and probably prevents issues
+  if (filepath[0] !== '.' && filepath[0] !== '/') {
+    filepath = `./${filepath}`;
+  }
+
+  return filepath;
 }
 
 function relatifyPath(filepath: string, rootDir: string): string {
@@ -18,11 +25,6 @@ function relatifyPath(filepath: string, rootDir: string): string {
   // Make root paths relative to the rootDir
   if (filepath[0] === '/') {
     filepath = normalisePath(path.relative(rootDir, filepath));
-  }
-
-  // Prefix relative paths with ./ as it makes it more clear and probably prevents issues
-  if (filepath[0] !== '.') {
-    filepath = `./${filepath}`;
   }
 
   return filepath;

--- a/src/utils.js
+++ b/src/utils.js
@@ -11,7 +11,7 @@ export function normalisePath(filepath: string): string {
   filepath = filepath.replace(/\\/g, '/');
 
   // Prefix relative paths with ./ as it makes it more clear and probably prevents issues
-  if (!path.isAbsolute(filepath)) {
+  if (filepath.length > 0 && filepath[0] !== '.' && !path.isAbsolute(filepath)) {
     filepath = `./${filepath}`;
   }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -11,7 +11,7 @@ export function normalisePath(filepath: string): string {
   filepath = filepath.replace(/\\/g, '/');
 
   // Prefix relative paths with ./ as it makes it more clear and probably prevents issues
-  if (filepath[0] !== '.' && filepath[0] !== '/') {
+  if (!path.isAbsolute(filepath)) {
     filepath = `./${filepath}`;
   }
 

--- a/src/wasm.js
+++ b/src/wasm.js
@@ -1,7 +1,8 @@
 // @flow
-import type { ParsedMap, VLQMap, SourceMapStringifyOptions, IndexedMapping } from './types';
+import type { ParsedMap, VLQMap, SourceMapStringifyOptions, IndexedMapping, GenerateEmptyMapOptions } from './types';
 import path from 'path';
 import SourceMap from './SourceMap';
+import {relatifyPath} from './utils';
 
 let Module;
 
@@ -36,14 +37,19 @@ function arrayToEmbind(Type, from): any {
 }
 
 export default class WasmSourceMap extends SourceMap {
-  constructor() {
-    super();
+  constructor(projectRoot: string = '/') {
+    super(projectRoot);
     this.sourceMapInstance = new Module.SourceMap();
   }
 
-  static generateEmptyMap(sourceName: string, sourceContent: string, lineOffset: number = 0): WasmSourceMap {
-    let map = new WasmSourceMap();
-    map.addEmptyMap(sourceName, sourceContent, lineOffset);
+  static generateEmptyMap({
+    projectRoot,
+    sourceName,
+    sourceContent,
+    lineOffset = 0,
+  }: GenerateEmptyMapOptions): WasmSourceMap {
+    let map = new WasmSourceMap(projectRoot);
+    map.addEmptyMap(relatifyPath(sourceName, projectRoot), sourceContent, lineOffset);
     return map;
   }
 
@@ -53,6 +59,7 @@ export default class WasmSourceMap extends SourceMap {
     columnOffset: number = 0
   ) {
     let { sourcesContent, sources = [], mappings, names = [] } = map;
+    sources = sources.map((source) => (source ? relatifyPath(source, this.projectRoot) : ''));
     if (!sourcesContent) {
       sourcesContent = sources.map(() => '');
     } else {

--- a/test/append.test.js
+++ b/test/append.test.js
@@ -4,13 +4,13 @@ const SourceMap = require('.').default;
 const SIMPLE_SOURCE_MAP = {
   version: 3,
   file: 'helloworld.js',
-  sources: ['helloworld.coffee'],
+  sources: ['./helloworld.coffee'],
   names: [],
   mappings: 'AAAA;AAAA,EAAA,OAAO,CAAC,GAAR,CAAY,aAAZ,CAAA,CAAA;AAAA',
 };
 
 let expectedResultOne = {
-  sources: ['helloworld.coffee'],
+  sources: ['./helloworld.coffee'],
   sourcesContent: [''],
   names: [],
   mappings: [
@@ -128,7 +128,7 @@ let expectedResultOne = {
 };
 
 let expectedResultTwo = {
-  sources: ['helloworld.coffee'],
+  sources: ['./helloworld.coffee'],
   sourcesContent: [''],
   names: [],
   mappings: [

--- a/test/append.test.js
+++ b/test/append.test.js
@@ -247,7 +247,7 @@ let expectedResultTwo = {
 
 describe('SourceMap - Append Mappings', () => {
   it('Append buffer mappings with line offset', () => {
-    let map = new SourceMap();
+    let map = new SourceMap('/test-root');
     map.addRawMappings({
       mappings: SIMPLE_SOURCE_MAP.mappings,
       sources: SIMPLE_SOURCE_MAP.sources,
@@ -259,7 +259,7 @@ describe('SourceMap - Append Mappings', () => {
   });
 
   it('Append buffer mappings with line and column offset', () => {
-    let map = new SourceMap();
+    let map = new SourceMap('/test-root');
     map.addRawMappings({
       mappings: SIMPLE_SOURCE_MAP.mappings,
       sources: SIMPLE_SOURCE_MAP.sources,
@@ -271,7 +271,7 @@ describe('SourceMap - Append Mappings', () => {
   });
 
   it('Append vlq mappings with line offset', () => {
-    let map = new SourceMap();
+    let map = new SourceMap('/test-root');
     map.addRawMappings({
       mappings: SIMPLE_SOURCE_MAP.mappings,
       sources: SIMPLE_SOURCE_MAP.sources,
@@ -289,7 +289,7 @@ describe('SourceMap - Append Mappings', () => {
   });
 
   it('Append vlq mappings with line and column offset', () => {
-    let map = new SourceMap();
+    let map = new SourceMap('/test-root');
     map.addRawMappings({
       mappings: SIMPLE_SOURCE_MAP.mappings,
       sources: SIMPLE_SOURCE_MAP.sources,
@@ -309,7 +309,7 @@ describe('SourceMap - Append Mappings', () => {
 
   it('Merge map with null mappings', async () => {
     const MAP_OFFSET = 24;
-    let map = new SourceMap();
+    let map = new SourceMap('/test-root');
 
     map.addIndexedMappings([
       {
@@ -446,7 +446,7 @@ describe('SourceMap - Append Mappings', () => {
   });
 
   it('Should be able to handle all variations of indexedmappings', async () => {
-    let map = new SourceMap();
+    let map = new SourceMap('/test-root');
 
     map.addIndexedMappings([
       {

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -11,7 +11,7 @@ const SIMPLE_SOURCE_MAP = {
 
 describe('SourceMap - Basics', () => {
   it('Should be able to instantiate a SourceMap with vlq mappings', async () => {
-    let map = new SourceMap();
+    let map = new SourceMap('/test-root');
     map.addRawMappings({
       mappings: SIMPLE_SOURCE_MAP.mappings,
       sources: SIMPLE_SOURCE_MAP.sources,
@@ -27,7 +27,7 @@ describe('SourceMap - Basics', () => {
   });
 
   it('Should be able to output the processed mappings as JS Objects', () => {
-    let map = new SourceMap();
+    let map = new SourceMap('/test-root');
     map.addRawMappings({
       mappings: SIMPLE_SOURCE_MAP.mappings,
       sources: SIMPLE_SOURCE_MAP.sources,
@@ -99,7 +99,7 @@ describe('SourceMap - Basics', () => {
   });
 
   it('Should be able to instantiate a SourceMap with processed mappings', async () => {
-    let map = new SourceMap();
+    let map = new SourceMap('/test-root');
 
     map.addIndexedMappings([
       {
@@ -134,7 +134,7 @@ describe('SourceMap - Basics', () => {
   });
 
   it('Should be able to handle undefined name field using addIndexedMappings', async () => {
-    let map = new SourceMap();
+    let map = new SourceMap('/test-root');
 
     map.addIndexedMappings([
       {
@@ -169,7 +169,7 @@ describe('SourceMap - Basics', () => {
   });
 
   it('Should be able to handle undefined name and source field using addIndexedMappings', async () => {
-    let map = new SourceMap();
+    let map = new SourceMap('/test-root');
 
     map.addIndexedMappings([
       {
@@ -201,7 +201,7 @@ describe('SourceMap - Basics', () => {
   });
 
   it('Should be able to create a SourceMap buffer and construct a new SourceMap from it', async () => {
-    let map = new SourceMap();
+    let map = new SourceMap('/test-root');
     map.addRawMappings({
       mappings: SIMPLE_SOURCE_MAP.mappings,
       sources: SIMPLE_SOURCE_MAP.sources,
@@ -230,7 +230,7 @@ describe('SourceMap - Basics', () => {
   });
 
   it('Should be able to add sources to a sourcemap', () => {
-    let map = new SourceMap();
+    let map = new SourceMap('/test-root');
     map.addRawMappings({
       mappings: SIMPLE_SOURCE_MAP.mappings,
       sources: SIMPLE_SOURCE_MAP.sources,
@@ -244,7 +244,7 @@ describe('SourceMap - Basics', () => {
   });
 
   it('Should be able to add names to a sourcemap', () => {
-    let map = new SourceMap();
+    let map = new SourceMap('/test-root');
     map.addRawMappings({
       mappings: SIMPLE_SOURCE_MAP.mappings,
       sources: SIMPLE_SOURCE_MAP.sources,
@@ -258,7 +258,7 @@ describe('SourceMap - Basics', () => {
   });
 
   it('Should be able to return source index', () => {
-    let map = new SourceMap();
+    let map = new SourceMap('/test-root');
     map.addRawMappings({
       mappings: SIMPLE_SOURCE_MAP.mappings,
       sources: SIMPLE_SOURCE_MAP.sources,
@@ -272,7 +272,7 @@ describe('SourceMap - Basics', () => {
   });
 
   it('Should be able to return name index', () => {
-    let map = new SourceMap();
+    let map = new SourceMap('/test-root');
     map.addRawMappings({
       mappings: SIMPLE_SOURCE_MAP.mappings,
       sources: SIMPLE_SOURCE_MAP.sources,
@@ -285,7 +285,7 @@ describe('SourceMap - Basics', () => {
   });
 
   it('Should be able to return source for a certain index', () => {
-    let map = new SourceMap();
+    let map = new SourceMap('/test-root');
     map.addRawMappings({
       mappings: SIMPLE_SOURCE_MAP.mappings,
       sources: SIMPLE_SOURCE_MAP.sources,
@@ -297,7 +297,7 @@ describe('SourceMap - Basics', () => {
   });
 
   it('Should be able to return name for a certain index', () => {
-    let map = new SourceMap();
+    let map = new SourceMap('/test-root');
     map.addRawMappings({
       mappings: SIMPLE_SOURCE_MAP.mappings,
       sources: SIMPLE_SOURCE_MAP.sources,
@@ -310,7 +310,7 @@ describe('SourceMap - Basics', () => {
   });
 
   it('Should be able to store and return sourceContents', async () => {
-    let map = new SourceMap();
+    let map = new SourceMap('/test-root');
     map.addRawMappings({
       mappings: SIMPLE_SOURCE_MAP.mappings,
       sources: SIMPLE_SOURCE_MAP.sources,

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -35,7 +35,7 @@ describe('SourceMap - Basics', () => {
     });
 
     assert.deepEqual(map.getMap(), {
-      sources: ['helloworld.coffee'],
+      sources: ['./helloworld.coffee'],
       sourcesContent: [''],
       names: [],
       mappings: [
@@ -292,7 +292,7 @@ describe('SourceMap - Basics', () => {
       names: SIMPLE_SOURCE_MAP.names,
     });
 
-    assert.equal(map.getSource(0), 'helloworld.coffee');
+    assert.equal(map.getSource(0), './helloworld.coffee');
     assert.equal(map.getSource(1), '');
   });
 

--- a/test/empty-map.test.js
+++ b/test/empty-map.test.js
@@ -3,18 +3,19 @@ const { generateEmptyMap } = require('.').default;
 
 describe('SourceMap - Empty Map', () => {
   it('Should be able to create a 1 to 1 map from a sourcefile', async () => {
-    let map = generateEmptyMap(
-      'index.js',
-      `
+    let map = generateEmptyMap({
+      projectRoot: '/test-root',
+      sourceName: '/test-root/index.js',
+      sourceContent: `
       function test() {
         return "hello world!";
       }
-    `
-    );
+    `,
+    });
 
     let mapContent = map.getMap();
     assert.deepEqual(mapContent, {
-      sources: ['index.js'],
+      sources: ['./index.js'],
       sourcesContent: [],
       names: [],
       mappings: [
@@ -43,19 +44,20 @@ describe('SourceMap - Empty Map', () => {
   });
 
   it('Should be able to create a 1 to 1 map from a sourcefile with a lineOffset', async () => {
-    let map = generateEmptyMap(
-      'index.js',
-      `
+    let map = generateEmptyMap({
+      projectRoot: '/test-root',
+      sourceName: 'index.js',
+      sourceContent: `
       function test() {
         return "hello world!";
       }
     `,
-      10
-    );
+      lineOffset: 10,
+    });
 
     let mapContent = map.getMap();
     assert.deepEqual(mapContent, {
-      sources: ['index.js'],
+      sources: ['./index.js'],
       sourcesContent: [],
       names: [],
       mappings: [

--- a/test/extend.test.js
+++ b/test/extend.test.js
@@ -3,7 +3,7 @@ const SourceMap = require('.').default;
 
 describe('SourceMap - Extend Map', () => {
   it('Basic extending', async function () {
-    let originalMap = new SourceMap();
+    let originalMap = new SourceMap('/test-root');
     originalMap.addIndexedMappings([
       {
         source: 'index.js',
@@ -19,7 +19,7 @@ describe('SourceMap - Extend Map', () => {
       },
     ]);
 
-    let newMap = new SourceMap();
+    let newMap = new SourceMap('/test-root');
     newMap.addIndexedMappings([
       {
         source: 'index.js',
@@ -72,7 +72,7 @@ describe('SourceMap - Extend Map', () => {
   });
 
   it('Extending null mappings', async function () {
-    let originalMap = new SourceMap();
+    let originalMap = new SourceMap('/test-root');
 
     originalMap.addIndexedMappings([
       {
@@ -95,7 +95,7 @@ describe('SourceMap - Extend Map', () => {
       },
     ]);
 
-    let newMap = new SourceMap();
+    let newMap = new SourceMap('/test-root');
 
     newMap.addIndexedMappings([
       {
@@ -167,7 +167,7 @@ describe('SourceMap - Extend Map', () => {
   });
 
   it('Basic extending w/ sourceContents', async function () {
-    let originalMap = new SourceMap();
+    let originalMap = new SourceMap('/test-root');
     originalMap.addIndexedMappings([
       {
         source: 'index.js',
@@ -185,7 +185,7 @@ describe('SourceMap - Extend Map', () => {
 
     originalMap.setSourceContent('index.js', '() => "test"');
 
-    let newMap = new SourceMap();
+    let newMap = new SourceMap('/test-root');
     newMap.addIndexedMappings([
       {
         source: 'index.js',

--- a/test/find.test.js
+++ b/test/find.test.js
@@ -3,7 +3,7 @@ const SourceMap = require('.').default;
 
 describe('SourceMap - Find', () => {
   it('Should be able to find closest mapping to a generated position', async () => {
-    let map = new SourceMap();
+    let map = new SourceMap('/test-root');
     map.addRawMappings({
       mappings: 'AAAA;AAAA,EAAA,OAAO,CAAC,GAAR,CAAY,aAAZ,CAAA,CAAA;AAAA',
       sources: ['helloworld.coffee'],

--- a/test/find.test.js
+++ b/test/find.test.js
@@ -14,14 +14,14 @@ describe('SourceMap - Find', () => {
     assert.deepEqual(mapping, {
       generated: { line: 2, column: 14 },
       original: { line: 1, column: 12 },
-      source: 'helloworld.coffee',
+      source: './helloworld.coffee',
     });
 
     mapping = map.findClosestMapping(2, 12);
     assert.deepEqual(mapping, {
       generated: { line: 2, column: 13 },
       original: { line: 1, column: 0 },
-      source: 'helloworld.coffee',
+      source: './helloworld.coffee',
     });
   });
 });

--- a/test/formats.test.js
+++ b/test/formats.test.js
@@ -11,7 +11,7 @@ const SIMPLE_SOURCE_MAP = {
 
 describe('SourceMap - Formats', () => {
   it('Should return a base64 encoded inline map when format is inline', async () => {
-    let map = new SourceMap();
+    let map = new SourceMap('/test-root');
     map.addRawMappings({
       mappings: SIMPLE_SOURCE_MAP.mappings,
       sources: SIMPLE_SOURCE_MAP.sources,
@@ -28,7 +28,7 @@ describe('SourceMap - Formats', () => {
   });
 
   it('Should return a stringified map when format is string', async () => {
-    let map = new SourceMap();
+    let map = new SourceMap('/test-root');
     map.addRawMappings({
       mappings: SIMPLE_SOURCE_MAP.mappings,
       sources: SIMPLE_SOURCE_MAP.sources,
@@ -45,7 +45,7 @@ describe('SourceMap - Formats', () => {
   });
 
   it('Should return an object map when format is object', async () => {
-    let map = new SourceMap();
+    let map = new SourceMap('/test-root');
     map.addRawMappings({
       mappings: SIMPLE_SOURCE_MAP.mappings,
       sources: SIMPLE_SOURCE_MAP.sources,
@@ -62,7 +62,7 @@ describe('SourceMap - Formats', () => {
   });
 
   it('Should make all sourcePaths relative to rootDir', async () => {
-    let map = new SourceMap();
+    let map = new SourceMap('/Users/test');
     map.addRawMappings({
       mappings: SIMPLE_SOURCE_MAP.mappings,
       sources: ['/Users/test/helloworld.coffee'],
@@ -71,7 +71,6 @@ describe('SourceMap - Formats', () => {
 
     let stringifiedMap = await map.stringify({
       file: 'index.js.map',
-      rootDir: '/Users/test/',
       sourceRoot: '/',
       format: 'object',
     });
@@ -80,7 +79,7 @@ describe('SourceMap - Formats', () => {
   });
 
   it('Should make all sourcePaths web friendly aka no windows backslashes', async () => {
-    let map = new SourceMap();
+    let map = new SourceMap('\\Users\\test\\');
     map.addRawMappings({
       mappings: SIMPLE_SOURCE_MAP.mappings,
       sources: ['\\Users\\test\\helloworld.coffee'],
@@ -89,7 +88,6 @@ describe('SourceMap - Formats', () => {
 
     let stringifiedMap = await map.stringify({
       file: 'index.js.map',
-      rootDir: '\\Users\\test\\',
       sourceRoot: '/',
       format: 'object',
     });

--- a/test/inline-source.test.js
+++ b/test/inline-source.test.js
@@ -17,7 +17,7 @@ const fileTwoContent = fs.readFileSync(path.join(ROOT_DIR, SIMPLE_SOURCE_MAP.sou
 
 describe('SourceMap - Inline Sources', () => {
   it('Should be able to inline sources', async () => {
-    let map = new SourceMap();
+    let map = new SourceMap(ROOT_DIR);
     map.addRawMappings({
       mappings: SIMPLE_SOURCE_MAP.mappings,
       sources: SIMPLE_SOURCE_MAP.sources,
@@ -29,7 +29,6 @@ describe('SourceMap - Inline Sources', () => {
       sourceRoot: '/',
       format: 'object',
       fs,
-      rootDir: ROOT_DIR,
       inlineSources: true,
     });
 
@@ -45,7 +44,7 @@ describe('SourceMap - Inline Sources', () => {
   });
 
   it('Should always inline sources outside the root', async () => {
-    let map = new SourceMap();
+    let map = new SourceMap(ROOT_DIR);
     map.addRawMappings({
       mappings: SIMPLE_SOURCE_MAP.mappings,
       sources: SIMPLE_SOURCE_MAP.sources,
@@ -57,7 +56,6 @@ describe('SourceMap - Inline Sources', () => {
       sourceRoot: '/',
       format: 'object',
       fs,
-      rootDir: ROOT_DIR,
       inlineSources: false,
     });
 
@@ -73,7 +71,7 @@ describe('SourceMap - Inline Sources', () => {
   });
 
   it('Should not overwrite existing sourceContent when inlining is true', async () => {
-    let map = new SourceMap();
+    let map = new SourceMap(ROOT_DIR);
     map.addRawMappings({
       mappings: SIMPLE_SOURCE_MAP.mappings,
       sources: SIMPLE_SOURCE_MAP.sources,
@@ -86,7 +84,6 @@ describe('SourceMap - Inline Sources', () => {
       sourceRoot: '/',
       format: 'object',
       fs,
-      rootDir: ROOT_DIR,
       inlineSources: true,
     });
 
@@ -102,7 +99,7 @@ describe('SourceMap - Inline Sources', () => {
   });
 
   it('Should not overwrite existing sourceContent when inlining is false', async () => {
-    let map = new SourceMap();
+    let map = new SourceMap(ROOT_DIR);
     map.addRawMappings({
       mappings: SIMPLE_SOURCE_MAP.mappings,
       sources: SIMPLE_SOURCE_MAP.sources,
@@ -115,7 +112,6 @@ describe('SourceMap - Inline Sources', () => {
       sourceRoot: '/',
       format: 'object',
       fs,
-      rootDir: ROOT_DIR,
       inlineSources: false,
     });
 

--- a/test/vlq.test.js
+++ b/test/vlq.test.js
@@ -11,7 +11,7 @@ const SIMPLE_SOURCE_MAP = {
 
 describe('SourceMap - VLQ', () => {
   it('Should be able to create simple VLQ output, using toVLQ', async () => {
-    let map = new SourceMap();
+    let map = new SourceMap('/test-root');
     map.addRawMappings({
       mappings: SIMPLE_SOURCE_MAP.mappings,
       sources: SIMPLE_SOURCE_MAP.sources,

--- a/test/vlq.test.js
+++ b/test/vlq.test.js
@@ -1,0 +1,23 @@
+const assert = require('assert');
+const SourceMap = require('.').default;
+
+const SIMPLE_SOURCE_MAP = {
+  version: 3,
+  file: 'helloworld.js',
+  sources: ['helloworld.coffee'],
+  names: [],
+  mappings: 'AAAA;AAAA,EAAA,OAAO,CAAC,GAAR,CAAY,aAAZ,CAAA,CAAA;AAAA',
+};
+
+describe('SourceMap - VLQ', () => {
+  it('Should be able to create simple VLQ output, using toVLQ', async () => {
+    let map = new SourceMap();
+    map.addRawMappings({
+      mappings: SIMPLE_SOURCE_MAP.mappings,
+      sources: SIMPLE_SOURCE_MAP.sources,
+      names: SIMPLE_SOURCE_MAP.names,
+    });
+    let stringifiedMap = map.toVLQ();
+    assert.equal(stringifiedMap.mappings, SIMPLE_SOURCE_MAP.mappings);
+  });
+});


### PR DESCRIPTION
This PR improves the way we handle source paths in this library to ensure we map mappings correctly by formatting each source path to ensure they're all equal, regardless of how they're formatted.

Most issues found while implementing esbuild for Parcel https://github.com/parcel-bundler/parcel/pull/5054

Maybe I should improve on this even further by adding the projectRoot as an option to create a sourcemap? This can ensure we always make each source relative to the projectRoot if absolute paths are provided.