### PR TITLE
Improve performance of addIndexedMappings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,17 @@
+{
+  "files.associations": {
+    "__node_handle": "cpp",
+    "__split_buffer": "cpp",
+    "array": "cpp",
+    "deque": "cpp",
+    "iterator": "cpp",
+    "queue": "cpp",
+    "set": "cpp",
+    "string": "cpp",
+    "string_view": "cpp",
+    "unordered_map": "cpp",
+    "vector": "cpp",
+    "__locale": "cpp",
+    "__string": "cpp"
+  }
+}

--- a/bench/run.js
+++ b/bench/run.js
@@ -8,7 +8,7 @@ const ITERATIONS = 250;
 init.then(() => {
   const suite = new Benchmark(ITERATIONS);
 
-  let mappings = new Array(10000).fill('').map((item, index) => {
+  let mappings = new Array(100).fill('').map((item, index) => {
     return {
       source: 'index.js',
       name: 'A',
@@ -28,7 +28,7 @@ init.then(() => {
   let sourcemapBuffer = sourcemapInstance.toBuffer();
   let rawSourceMap = sourcemapInstance.toVLQ();
 
-  /*suite.add('consume vlq mappings', async () => {
+  suite.add('consume vlq mappings', async () => {
     let map = new SourceMap();
     map.addRawMappings({
       mappings: rawSourceMap.mappings,
@@ -42,7 +42,7 @@ init.then(() => {
     let map = new SourceMap();
     map.addBufferMappings(sourcemapBuffer);
     map.delete();
-  });*/
+  });
 
   suite.add('consume JS Mappings', async () => {
     let map = new SourceMap();
@@ -50,7 +50,7 @@ init.then(() => {
     map.delete();
   });
 
-  /*suite.add('JS Mappings => vlq (mozilla source-map) => buffer', async () => {
+  suite.add('JS Mappings => vlq (mozilla source-map) => buffer', async () => {
     let map = new MozillaSourceMap.SourceMapGenerator({
       sourceRoot: '/',
     });
@@ -123,7 +123,7 @@ init.then(() => {
       format: 'object',
     });
     map.delete();
-  });*/
+  });
 
   suite.run();
 });

--- a/bench/run.js
+++ b/bench/run.js
@@ -8,7 +8,7 @@ const ITERATIONS = 250;
 init.then(() => {
   const suite = new Benchmark(ITERATIONS);
 
-  let mappings = new Array(100).fill('').map((item, index) => {
+  let mappings = new Array(10000).fill('').map((item, index) => {
     return {
       source: 'index.js',
       name: 'A',
@@ -28,7 +28,7 @@ init.then(() => {
   let sourcemapBuffer = sourcemapInstance.toBuffer();
   let rawSourceMap = sourcemapInstance.toVLQ();
 
-  suite.add('consume vlq mappings', async () => {
+  /*suite.add('consume vlq mappings', async () => {
     let map = new SourceMap();
     map.addRawMappings({
       mappings: rawSourceMap.mappings,
@@ -42,7 +42,7 @@ init.then(() => {
     let map = new SourceMap();
     map.addBufferMappings(sourcemapBuffer);
     map.delete();
-  });
+  });*/
 
   suite.add('consume JS Mappings', async () => {
     let map = new SourceMap();
@@ -50,7 +50,7 @@ init.then(() => {
     map.delete();
   });
 
-  suite.add('JS Mappings => vlq (mozilla source-map) => buffer', async () => {
+  /*suite.add('JS Mappings => vlq (mozilla source-map) => buffer', async () => {
     let map = new MozillaSourceMap.SourceMapGenerator({
       sourceRoot: '/',
     });
@@ -123,7 +123,7 @@ init.then(() => {
       format: 'object',
     });
     map.delete();
-  });
+  });*/
 
   suite.run();
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parcel/source-map",
-  "version": "2.0.0-alpha.4.18",
+  "version": "2.0.0-alpha.4.19",
   "main": "./dist/node.js",
   "types": "index.d.ts",
   "browser": "./dist/wasm-browser.js",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "lint": "prettier --write bench/run.js src/*.js",
     "typecheck": "flow",
     "format": "prettier --write \"./**/*.{js,md,mdx}\"",
-    "compile-schema": "./flatc --cpp -o ./src ./src/sourcemap-schema.fbs"
+    "compile-schema": "./flatc --cpp -o ./src ./src/sourcemap-schema.fbs",
+    "clean": "rm -rf dist build"
   },
   "husky": {
     "hooks": {

--- a/src/MappingContainer.cpp
+++ b/src/MappingContainer.cpp
@@ -487,21 +487,9 @@ void MappingContainer::addBufferMappings(const void *buf, int lineOffset, int co
 }
 
 void MappingContainer::addIndexedMapping(int generatedLine, int generatedColumn, int originalLine, int originalColumn,
-                                         std::string source, std::string name) {
+                                         int sourceIndex, int nameIndex) {
     Position generatedPosition = Position{generatedLine, generatedColumn};
     Position originalPosition = Position{originalLine, originalColumn};
-    int sourceIndex = -1;
-    int nameIndex = -1;
-    if (originalPosition.line > -1) {
-        if (!source.empty()) {
-            sourceIndex = addSource(source);
-        }
-
-        if (!name.empty()) {
-            nameIndex = addName(name);
-        }
-    }
-
     addMapping(generatedPosition, originalPosition, sourceIndex, nameIndex);
 }
 

--- a/src/MappingContainer.cpp
+++ b/src/MappingContainer.cpp
@@ -490,6 +490,12 @@ void MappingContainer::addIndexedMapping(int generatedLine, int generatedColumn,
                                          int sourceIndex, int nameIndex) {
     Position generatedPosition = Position{generatedLine, generatedColumn};
     Position originalPosition = Position{originalLine, originalColumn};
+    
+    if (originalPosition.line < 0) {
+        sourceIndex = -1;
+        nameIndex = -1;
+    }
+
     addMapping(generatedPosition, originalPosition, sourceIndex, nameIndex);
 }
 

--- a/src/MappingContainer.h
+++ b/src/MappingContainer.h
@@ -64,7 +64,7 @@ public:
 
     void offsetColumns(int line, int column, int columnOffset);
 
-    void addIndexedMapping(int generatedLine, int generatedColumn, int originalLine, int originalColumn, std::string source, std::string name);
+    void addIndexedMapping(int generatedLine, int generatedColumn, int originalLine, int originalColumn, int sourceIndex, int nameIndex);
 
 private:
     // Processed mappings, for all kinds of modifying within the sourcemap

--- a/src/SourceMap.js
+++ b/src/SourceMap.js
@@ -86,22 +86,11 @@ export default class SourceMap {
     this.addIndexedMappings([mapping], lineOffset, columnOffset);
   }
 
-  /**
-   * Appends an array of Mapping objects to this sourcemap
-   * This is useful when improving performance if a library provides the non-serialised mappings
-   *
-   * Note: This is only faster if they generate the serialised map lazily
-   * Note: line numbers start at 1 due to mozilla's source-map library
-   *
-   * @param mappings an array of mapping objects
-   * @param lineOffset an offset that gets added to the sourceLine index of each mapping
-   * @param columnOffset  an offset that gets added to the sourceColumn index of each mapping
-   */
-  addIndexedMappings(
+  _indexedMappingsToInt32Array(
     mappings: Array<IndexedMapping<string>>,
     lineOffset?: number = 0,
     columnOffset?: number = 0
-  ): SourceMap {
+  ) {
     // Encode all mappings into a single typed array and make one call
     // to C++ instead of one for each mapping to improve performance.
     let mappingBuffer = new Int32Array(mappings.length * 6);
@@ -142,9 +131,26 @@ export default class SourceMap {
       mappingBuffer[i++] = nameIndex;
     }
 
-    this.sourceMapInstance.addIndexedMappings(mappingBuffer);
+    return mappingBuffer;
+  }
 
-    return this;
+  /**
+   * Appends an array of Mapping objects to this sourcemap
+   * This is useful when improving performance if a library provides the non-serialised mappings
+   *
+   * Note: This is only faster if they generate the serialised map lazily
+   * Note: line numbers start at 1 due to mozilla's source-map library
+   *
+   * @param mappings an array of mapping objects
+   * @param lineOffset an offset that gets added to the sourceLine index of each mapping
+   * @param columnOffset  an offset that gets added to the sourceColumn index of each mapping
+   */
+  addIndexedMappings(
+    mappings: Array<IndexedMapping<string>>,
+    lineOffset?: number = 0,
+    columnOffset?: number = 0
+  ): SourceMap {
+    throw new Error('Should be implemented by child class');
   }
 
   /**

--- a/src/napi/SourceMap.h
+++ b/src/napi/SourceMap.h
@@ -15,8 +15,6 @@ private:
 
     void addBufferMappings(const Napi::CallbackInfo &info);
 
-    void addIndexedMapping(const Napi::CallbackInfo &info);
-
     void addIndexedMappings(const Napi::CallbackInfo &info);
 
     void extends(const Napi::CallbackInfo &info);

--- a/src/node.js
+++ b/src/node.js
@@ -30,56 +30,6 @@ export default class NodeSourceMap extends SourceMap {
     return this;
   }
 
-  addIndexedMappings(
-    mappings: Array<IndexedMapping<string>>,
-    lineOffset?: number = 0,
-    columnOffset?: number = 0
-  ): SourceMap {
-    // Encode all mappings into a single typed array and make one call
-    // to C++ instead of one for each mapping to improve performance.
-    let mappingBuffer = new Int32Array(mappings.length * 6);
-    let sources: Map<string, number> = new Map();
-    let names: Map<string, number> = new Map();
-    let i = 0;
-    for (let mapping of mappings) {
-      let hasValidOriginal =
-        mapping.original &&
-        typeof mapping.original.line === 'number' &&
-        !isNaN(mapping.original.line) &&
-        typeof mapping.original.column === 'number' &&
-        !isNaN(mapping.original.column);
-
-      mappingBuffer[i++] = mapping.generated.line + lineOffset - 1;
-      mappingBuffer[i++] = mapping.generated.column + columnOffset;
-      // $FlowFixMe
-      mappingBuffer[i++] = hasValidOriginal ? mapping.original.line - 1 : -1;
-      // $FlowFixMe
-      mappingBuffer[i++] = hasValidOriginal ? mapping.original.column : -1;
-
-      let sourceIndex = mapping.source ? sources.get(mapping.source) : -1;
-      if (sourceIndex == null) {
-        // $FlowFixMe
-        sourceIndex = this.addSource(mapping.source);
-        // $FlowFixMe
-        sources.set(mapping.source, sourceIndex);
-      }
-      mappingBuffer[i++] = sourceIndex;
-
-      let nameIndex = mapping.name ? names.get(mapping.name) : -1;
-      if (nameIndex == null) {
-        // $FlowFixMe
-        nameIndex = this.addName(mapping.name);
-        // $FlowFixMe
-        names.set(mapping.name, nameIndex);
-      }
-      mappingBuffer[i++] = nameIndex;
-    }
-
-    this.sourceMapInstance.addIndexedMappings(mappingBuffer);
-
-    return this;
-  }
-
   toBuffer(): Buffer {
     return this.sourceMapInstance.toBuffer();
   }

--- a/src/node.js
+++ b/src/node.js
@@ -30,6 +30,16 @@ export default class NodeSourceMap extends SourceMap {
     return this;
   }
 
+  addIndexedMappings(
+    mappings: Array<IndexedMapping<string>>,
+    lineOffset?: number = 0,
+    columnOffset?: number = 0
+  ): SourceMap {
+    let mappingBuffer = this._indexedMappingsToInt32Array(mappings, lineOffset, columnOffset);
+    this.sourceMapInstance.addIndexedMappings(mappingBuffer);
+    return this;
+  }
+
   toBuffer(): Buffer {
     return this.sourceMapInstance.toBuffer();
   }

--- a/src/node.js
+++ b/src/node.js
@@ -37,9 +37,9 @@ export default class NodeSourceMap extends SourceMap {
   ): SourceMap {
     // Encode all mappings into a single typed array and make one call
     // to C++ instead of one for each mapping to improve performance.
-    let mappingBuffer = new Int32Array(mappings.length * 4);
-    let sources = [];
-    let names = [];
+    let mappingBuffer = new Int32Array(mappings.length * 6);
+    let sources: Map<string, number> = new Map();
+    let names: Map<string, number> = new Map();
     let i = 0;
     for (let mapping of mappings) {
       let hasValidOriginal =
@@ -55,11 +55,27 @@ export default class NodeSourceMap extends SourceMap {
       mappingBuffer[i++] = hasValidOriginal ? mapping.original.line - 1 : -1;
       // $FlowFixMe
       mappingBuffer[i++] = hasValidOriginal ? mapping.original.column : -1;
-      sources.push(mapping.source ? relatifyPath(mapping.source, this.projectRoot) : '');
-      names.push(mapping.name || '');
+
+      let sourceIndex = mapping.source ? sources.get(mapping.source) : -1;
+      if (sourceIndex == null) {
+        // $FlowFixMe
+        sourceIndex = this.addSource(mapping.source);
+        // $FlowFixMe
+        sources.set(mapping.source, sourceIndex);
+      }
+      mappingBuffer[i++] = sourceIndex;
+
+      let nameIndex = mapping.name ? names.get(mapping.name) : -1;
+      if (nameIndex == null) {
+        // $FlowFixMe
+        nameIndex = this.addName(mapping.name);
+        // $FlowFixMe
+        names.set(mapping.name, nameIndex);
+      }
+      mappingBuffer[i++] = nameIndex;
     }
 
-    this.sourceMapInstance.addIndexedMappings(mappingBuffer, sources, names);
+    this.sourceMapInstance.addIndexedMappings(mappingBuffer);
 
     return this;
   }

--- a/src/utils.js
+++ b/src/utils.js
@@ -17,7 +17,11 @@ export function isAbsolute(filepath: string): boolean {
 }
 
 export function normalizePath(filepath: string): string {
-  return filepath.replace(ABSOLUTE_PATH_REGEX, '/').replace(PATH_SEPARATOR_REGEX, '/');
+  if (process.platform === 'win32') {
+    return filepath.replace(ABSOLUTE_PATH_REGEX, '/').replace(PATH_SEPARATOR_REGEX, '/');
+  }
+
+  return filepath;
 }
 
 export function relatifyPath(filepath: string, rootDir: string): string {

--- a/src/wasm.js
+++ b/src/wasm.js
@@ -28,8 +28,8 @@ function patchMapping(mapping: any): any {
   return mapping;
 }
 
-function arrayToEmbind(Type, from): any {
-  let arr = new Module.VectorString();
+function arrayToEmbind(VectorType, from): any {
+  let arr = new VectorType();
   for (let v of from) {
     arr.push_back(v);
   }
@@ -79,6 +79,18 @@ export default class WasmSourceMap extends SourceMap {
     sourcesVector.delete();
     sourcesContentVector.delete();
     namesVector.delete();
+    return this;
+  }
+
+  addIndexedMappings(
+    mappings: Array<IndexedMapping<string>>,
+    lineOffset?: number = 0,
+    columnOffset?: number = 0
+  ): SourceMap {
+    let mappingBuffer = this._indexedMappingsToInt32Array(mappings, lineOffset, columnOffset);
+    let mappingBufferArray = arrayToEmbind(Module.VectorInt, mappingBuffer);
+    this.sourceMapInstance.addIndexedMappings(mappingBufferArray);
+    mappingBufferArray.delete();
     return this;
   }
 

--- a/src/wasm/SourceMap.cpp
+++ b/src/wasm/SourceMap.cpp
@@ -62,9 +62,21 @@ std::vector<Mapping> SourceMap::getMappings(){
     return mappings;
 }
 
-// addIndexedMapping(generatedLine, generatedColumn, originalLine, originalColumn, source, name)
-void SourceMap::addIndexedMapping(int generatedLine, int generatedColumn, int originalLine, int originalColumn, std::string source, std::string name) {
-    _mapping_container.addIndexedMapping(generatedLine, generatedColumn, originalLine, originalColumn, source, name);
+// addIndexedMappings(mappings: Vector<Int32>)
+void SourceMap::addIndexedMappings(std::vector<int> buffer) {
+    unsigned int length = buffer.size();
+    for (unsigned int i = 0; i < length; i += 6) {
+        unsigned int mappingIndex = i / 6;
+
+        _mapping_container.addIndexedMapping(
+                buffer[i],
+                buffer[i + 1],
+                buffer[i + 2],
+                buffer[i + 3],
+                buffer[i + 4],
+                buffer[i + 5]
+        );
+    }
 }
 
 int SourceMap::getSourceIndex(std::string source) {
@@ -147,7 +159,7 @@ EMSCRIPTEN_BINDINGS(my_class_example) {
         .constructor<>()
         .function("addRawMappings", &SourceMap::addRawMappings)
         .function("addBufferMappings", &SourceMap::addBufferMappings)
-        .function("addIndexedMapping", &SourceMap::addIndexedMapping)
+        .function("addIndexedMappings", &SourceMap::addIndexedMappings)
         .function("getVLQMappings", &SourceMap::getVLQMappings)
         .function("getMappings", &SourceMap::getMappings)
         .function("getSources", &SourceMap::getSources)

--- a/src/wasm/SourceMap.h
+++ b/src/wasm/SourceMap.h
@@ -9,7 +9,7 @@ public:
 
     void addRawMappings(std::string rawMappings, std::vector<std::string> sources, std::vector<std::string> sourcesContent, std::vector<std::string> names, int lineOffset, int columnOffset);
     void addBufferMappings(std::string mapbuffer, int lineOffset, int columnOffset);
-    void addIndexedMapping(int generatedLine, int generatedColumn, int originalLine, int originalColumn, std::string source, std::string name);
+    void addIndexedMappings(std::vector<int> buffer);
 
     void extends(std::string mapBuffer);
 

--- a/test/formats.test.js
+++ b/test/formats.test.js
@@ -78,20 +78,32 @@ describe('SourceMap - Formats', () => {
     assert.deepEqual(stringifiedMap.sources, ['./helloworld.coffee']);
   });
 
-  it('Should make all sourcePaths web friendly aka no windows backslashes', async () => {
-    let map = new SourceMap('C:\\Users\\test\\');
-    map.addRawMappings({
-      mappings: SIMPLE_SOURCE_MAP.mappings,
-      sources: ['C:\\Users\\test\\helloworld.coffee'],
-      names: SIMPLE_SOURCE_MAP.names,
+  describe('win32', function () {
+    let platform = process.platform;
+
+    before(() => {
+      Object.defineProperty(process, 'platform', { value: 'win32' });
     });
 
-    let stringifiedMap = await map.stringify({
-      file: 'index.js.map',
-      sourceRoot: '/',
-      format: 'object',
+    after(() => {
+      Object.defineProperty(process, 'platform', { value: platform });
     });
 
-    assert.deepEqual(stringifiedMap.sources, ['./helloworld.coffee']);
+    it('Should make all sourcePaths web friendly aka no windows backslashes', async () => {
+      let map = new SourceMap('C:\\Users\\test\\');
+      map.addRawMappings({
+        mappings: SIMPLE_SOURCE_MAP.mappings,
+        sources: ['C:\\Users\\test\\helloworld.coffee'],
+        names: SIMPLE_SOURCE_MAP.names,
+      });
+
+      let stringifiedMap = await map.stringify({
+        file: 'index.js.map',
+        sourceRoot: '/',
+        format: 'object',
+      });
+
+      assert.deepEqual(stringifiedMap.sources, ['./helloworld.coffee']);
+    });
   });
 });

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -2,15 +2,15 @@ import assert from 'assert';
 import { normalizePath, relatifyPath } from '../src/utils';
 
 describe('Utilities', () => {
-  describe('win32', function() {
+  describe('win32', function () {
     let platform = process.platform;
 
     before(() => {
-      Object.defineProperty(process, 'platform', {value: 'win32'});
+      Object.defineProperty(process, 'platform', { value: 'win32' });
     });
 
     after(() => {
-      Object.defineProperty(process, 'platform', {value: platform});
+      Object.defineProperty(process, 'platform', { value: platform });
     });
 
     it('Relative path', async () => {

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -2,33 +2,37 @@ import assert from 'assert';
 import { normalizePath, relatifyPath } from '../src/utils';
 
 describe('Utilities', () => {
-  it('Relative path - WIN32', async () => {
-    let result = relatifyPath('D:\\test\\sub-dir\\file.js', 'D:\\test\\sub-dir\\');
-    assert.equal(result, './file.js');
+  describe('win32', function() {
+    let platform = process.platform;
+
+    before(() => {
+      Object.defineProperty(process, 'platform', {value: 'win32'});
+    });
+
+    after(() => {
+      Object.defineProperty(process, 'platform', {value: platform});
+    });
+
+    it('Relative path', async () => {
+      let result = relatifyPath('D:\\test\\sub-dir\\file.js', 'D:\\test\\sub-dir\\');
+      assert.equal(result, './file.js');
+    });
+
+    it('Normalize path', async () => {
+      let result = normalizePath('D:\\test\\sub-dir\\file.js');
+      assert.equal(result, '/test/sub-dir/file.js');
+    });
   });
 
-  it('Relative path - POSIX', async () => {
-    let result = relatifyPath('\\test\\sub-dir\\file.js', '\\test\\sub-dir\\');
-    assert.equal(result, './file.js');
-  });
+  describe('posix', function () {
+    it('Relative path', async () => {
+      let result = relatifyPath('/test/sub-dir/file.js', '/test/sub-dir/');
+      assert.equal(result, './file.js');
+    });
 
-  it('Relative path - POSIX', async () => {
-    let result = relatifyPath('/test/sub-dir/file.js', '/test/sub-dir/');
-    assert.equal(result, './file.js');
-  });
-
-  it('Normalize path - WIN32', async () => {
-    let result = normalizePath('D:\\test\\sub-dir\\file.js');
-    assert.equal(result, '/test/sub-dir/file.js');
-  });
-
-  it('Normalize path - POSIX', async () => {
-    let result = normalizePath('\\test\\sub-dir\\file.js');
-    assert.equal(result, '/test/sub-dir/file.js');
-  });
-
-  it('Normalize path - POSIX', async () => {
-    let result = normalizePath('/test/sub-dir/file.js');
-    assert.equal(result, '/test/sub-dir/file.js');
+    it('Normalize path', async () => {
+      let result = normalizePath('/test/sub-dir/file.js');
+      assert.equal(result, '/test/sub-dir/file.js');
+    });
   });
 });


### PR DESCRIPTION
This does two things:

1. Does not normalize path separators except on windows since this is expensive.
2. Implements `addIndexedMappings` natively for napi so that it is a single native call instead of one for each mapping. This is done by encoding all mappings into a buffer to pass them to C++.

Before:

```
consume JS Mappings 6404.88 opts/sec (mean: 0.156ms, stddev: 0.122ms, 250 samples)
```

After:

```
consume JS Mappings 20021.29 opts/sec (mean: 0.1ms, stddev: 0.193ms, 250 samples)
```

This improves overall build perf for three.js by ~3%.