### PR TITLE
Bump requirement to Node 12

### DIFF
--- a/azure-pipelines-template.yml
+++ b/azure-pipelines-template.yml
@@ -19,10 +19,10 @@ jobs:
     strategy:
       matrix:
         node_10_x:
-          node_version: 10.x
+          node_version: 12.x
           publish_artifacts: false
         node_12_x:
-          node_version: 12.x
+          node_version: 14.x
           publish_artifacts: true
     steps:
       - task: NodeTool@0

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     ]
   },
   "engines": {
-    "node": "^10 || ^12.18.3 || >=14"
+    "node": "^12.18.3 || >=14"
   },
   "dependencies": {
     "node-addon-api": "^3.0.0",


### PR DESCRIPTION
Apparently, Node 10 doesn't work anyway.

Closes https://github.com/parcel-bundler/source-map/issues/48
