### PR TITLE
Improve findClosestMapping

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "mocha": "^7.1.2",
     "prebuildify": "^4.1.1",
     "prettier": "^2.0.5",
+    "segfault-handler": "^1.3.0",
     "shx": "^0.3.3",
     "source-map": "^0.7.3",
     "tiny-benchy": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -73,7 +73,6 @@
     "mocha": "^7.1.2",
     "prebuildify": "^4.1.1",
     "prettier": "^2.0.5",
-    "segfault-handler": "^1.3.0",
     "shx": "^0.3.3",
     "source-map": "^0.7.3",
     "tiny-benchy": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parcel/source-map",
-  "version": "2.0.0-alpha.4.20",
+  "version": "2.0.0-alpha.4.21",
   "main": "./dist/node.js",
   "types": "index.d.ts",
   "browser": "./dist/wasm-browser.js",

--- a/src/MappingContainer.cpp
+++ b/src/MappingContainer.cpp
@@ -197,7 +197,7 @@ Mapping MappingContainer::findClosestMapping(int lineIndex, int columnIndex) {
         int stopIndex = segmentsCount - 1;
         int middleIndex = ((stopIndex + startIndex) / 2);
         while (startIndex < stopIndex) {
-            Mapping &mapping = segments[middleIndex];
+            Mapping &mapping = segments.at(middleIndex);
             int diff = mapping.generated.column - columnIndex;
             if (diff > 0) {
                 --stopIndex;
@@ -210,7 +210,7 @@ Mapping MappingContainer::findClosestMapping(int lineIndex, int columnIndex) {
             middleIndex = ((stopIndex + startIndex) / 2);
         }
 
-        return segments[middleIndex];
+        return segments.at(middleIndex);
     }
 
     return Mapping{Position{-1, -1}, Position{-1, -1}, -1, -1};

--- a/src/MappingContainer.cpp
+++ b/src/MappingContainer.cpp
@@ -188,7 +188,7 @@ std::string MappingContainer::toVLQMappings() {
 }
 
 Mapping MappingContainer::findClosestMapping(int lineIndex, int columnIndex) {
-    if (lineIndex <= _generated_lines) {
+    if (lineIndex <= _generated_lines && lineIndex >= 0) {
         auto &line = _mapping_lines.at(lineIndex);
         auto &segments = line._segments;
         unsigned int segmentsCount = segments.size();

--- a/src/MappingContainer.cpp
+++ b/src/MappingContainer.cpp
@@ -190,30 +190,10 @@ std::string MappingContainer::toVLQMappings() {
 Mapping MappingContainer::findClosestMapping(int lineIndex, int columnIndex) {
     if (lineIndex <= _generated_lines && lineIndex >= 0) {
         auto &line = _mapping_lines.at(lineIndex);
-        auto &segments = line._segments;
-        unsigned int segmentsCount = segments.size();
-
-        int startIndex = 0;
-        int stopIndex = segmentsCount - 1;
-        int middleIndex = ((stopIndex + startIndex) / 2);
-        while (startIndex < stopIndex) {
-            Mapping &mapping = segments.at(middleIndex);
-            int diff = mapping.generated.column - columnIndex;
-            if (diff > 0) {
-                --stopIndex;
-            } else if (diff < 0) {
-                ++startIndex;
-            } else {
-                break;
-            }
-
-            middleIndex = ((stopIndex + startIndex) / 2);
-        }
-
-        return segments.at(middleIndex);
+        return line.findClosestMapping(columnIndex);
+    } else {
+        return Mapping{Position{-1, -1}, Position{-1, -1}, -1, -1};
     }
-
-    return Mapping{Position{-1, -1}, Position{-1, -1}, -1, -1};
 }
 
 int MappingContainer::getTotalSegments() {

--- a/src/MappingLine.cpp
+++ b/src/MappingLine.cpp
@@ -34,6 +34,29 @@ int MappingLine::lineNumber() {
     return _line_number;
 }
 
+int MappingLine::lastColumn() {
+    return _last_column;
+}
+
+Mapping MappingLine::findClosestMapping(int columnIndex) {
+    // Ensure mappings are sorted
+    sort();
+
+    if (_segments.size() > 0) {
+        Mapping searchValue = Mapping{Position{_line_number, columnIndex}, Position{-1, -1}, -1, -1};
+        std::vector<Mapping>::iterator low = std::lower_bound(_segments.begin(), _segments.end(), searchValue, [](const Mapping& mappingA, const Mapping& mappingB){
+            return mappingA.generated.column < mappingB.generated.column;
+        });
+        if (low != _segments.end()) {
+            return *low;
+        } else {
+            return _segments.at(0);
+        }
+    }
+
+    return Mapping{Position{-1, -1}, Position{-1, -1}, -1, -1};
+}
+
 void MappingLine::clearMappings() {
     this->_segments.clear();
     this->_last_column = 0;

--- a/src/MappingLine.cpp
+++ b/src/MappingLine.cpp
@@ -47,8 +47,21 @@ Mapping MappingLine::findClosestMapping(int columnIndex) {
         std::vector<Mapping>::iterator low = std::lower_bound(_segments.begin(), _segments.end(), searchValue, [](const Mapping& mappingA, const Mapping& mappingB){
             return mappingA.generated.column < mappingB.generated.column;
         });
+
         if (low != _segments.end()) {
-            return *low;
+            Mapping currMapping = *low;
+            if (++low != _segments.end()) {
+                Mapping nextMapping = *low;
+
+                int nextMappingDiff = nextMapping.generated.column - columnIndex;
+                int currMappingDiff = columnIndex - currMapping.generated.column;
+
+                if (nextMappingDiff < currMappingDiff) {
+                    return nextMapping;
+                }
+            }
+
+            return currMapping;
         } else {
             return _segments.at(0);
         }

--- a/src/MappingLine.h
+++ b/src/MappingLine.h
@@ -25,6 +25,4 @@ private:
     bool _is_sorted = false;
     int _line_number = 0;
     int _last_column = 0;
-
-    int binarySearchColumn(int startIndex, int endIndex, int columnIndex);
 };

--- a/src/MappingLine.h
+++ b/src/MappingLine.h
@@ -15,10 +15,16 @@ public:
 
     int lineNumber();
 
+    int lastColumn();
+
+    Mapping findClosestMapping(int columnIndex);
+
     std::vector<Mapping> _segments;
 
 private:
     bool _is_sorted = false;
     int _line_number = 0;
     int _last_column = 0;
+
+    int binarySearchColumn(int startIndex, int endIndex, int columnIndex);
 };

--- a/src/node.js
+++ b/src/node.js
@@ -46,8 +46,12 @@ export default class NodeSourceMap extends SourceMap {
 
   findClosestMapping(line: number, column: number): ?IndexedMapping<string> {
     let mapping = this.sourceMapInstance.findClosestMapping(line, column);
-    let v = this.indexedMappingToStringMapping(mapping);
-    return v;
+    if (mapping.generated.line === -1 || mapping.generated.column === -1) {
+      return null;
+    } else {
+      let v = this.indexedMappingToStringMapping(mapping);
+      return v;
+    }
   }
 
   delete() {}

--- a/src/wasm.js
+++ b/src/wasm.js
@@ -96,7 +96,7 @@ export default class WasmSourceMap extends SourceMap {
 
   findClosestMapping(line: number, column: number): ?IndexedMapping<string> {
     let mapping = this.sourceMapInstance.findClosestMapping(line, column);
-    if (mapping.generated.line === -1) {
+    if (mapping.generated.line === -1 || mapping.generated.column === -1) {
       return null;
     } else {
       let m = { ...mapping };

--- a/test/find.test.js
+++ b/test/find.test.js
@@ -1,7 +1,7 @@
 import assert from 'assert';
 import SourceMap from '.';
 
-describe('SourceMap - Find', () => {
+describe.only('SourceMap - Find', () => {
   it('Should be able to find closest mapping to a generated position', async () => {
     let map = new SourceMap('/test-root');
     map.addRawMappings({

--- a/test/find.test.js
+++ b/test/find.test.js
@@ -1,7 +1,7 @@
 import assert from 'assert';
 import SourceMap from '.';
 
-describe.only('SourceMap - Find', () => {
+describe('SourceMap - Find', () => {
   it('Should be able to find closest mapping to a generated position', async () => {
     let map = new SourceMap('/test-root');
     map.addRawMappings({
@@ -10,7 +10,14 @@ describe.only('SourceMap - Find', () => {
       names: [],
     });
 
-    let mapping = map.findClosestMapping(2, 14);
+    let mapping = map.findClosestMapping(2, 8);
+    assert.deepEqual(mapping, {
+      generated: { line: 2, column: 9 },
+      original: { line: 1, column: 7 },
+      source: './helloworld.coffee',
+    });
+
+    mapping = map.findClosestMapping(2, 14);
     assert.deepEqual(mapping, {
       generated: { line: 2, column: 14 },
       original: { line: 1, column: 12 },

--- a/test/find.test.js
+++ b/test/find.test.js
@@ -23,5 +23,15 @@ describe('SourceMap - Find', () => {
       original: { line: 1, column: 0 },
       source: './helloworld.coffee',
     });
+
+    mapping = map.findClosestMapping(3, 15);
+    assert.deepEqual(mapping, {
+      generated: { line: 3, column: 0 },
+      original: { line: 1, column: 0 },
+      source: './helloworld.coffee',
+    });
+
+    mapping = map.findClosestMapping(50, 15);
+    assert.equal(mapping, null);
   });
 });

--- a/test/find.test.js
+++ b/test/find.test.js
@@ -31,7 +31,14 @@ describe('SourceMap - Find', () => {
       source: './helloworld.coffee',
     });
 
+    // Edge cases
     mapping = map.findClosestMapping(50, 15);
     assert.equal(mapping, null);
+
+    mapping = map.findClosestMapping(0, 0);
+    assert.deepEqual(mapping, null);
+
+    mapping = map.findClosestMapping(-2, -6);
+    assert.deepEqual(mapping, null);
   });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,3 @@
-require('segfault-handler');
-
 if (!process.env.BACKEND || process.env.BACKEND === 'node') {
   module.exports = require('../dist/node');
 } else if (process.env.BACKEND === 'wasm') {

--- a/test/index.js
+++ b/test/index.js
@@ -1,3 +1,5 @@
+require('segfault-handler');
+
 if (!process.env.BACKEND || process.env.BACKEND === 'node') {
   module.exports = require('../dist/node');
 } else if (process.env.BACKEND === 'wasm') {


### PR DESCRIPTION
This PR improves the findClosestMapping logic to return null if no mapping is found instead of returning the -1 mapping and no longer use a binary search but instead use the lower_bound util that is part of CPP.

This PR also ensures mappings are sorted before finding closest mapping, further increasing reliability.
