### PR TITLE
Improve perf of adding JS mappings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,7 @@
+[workspace]
+members = [ "parcel_sourcemap", "parcel_sourcemap_node", "parcel_sourcemap_wasm" ]
+
+[profile.release]
+lto = true
+opt-level = 3
+codegen-units = 1

--- a/cargo.toml
+++ b/cargo.toml
@@ -1,2 +1,0 @@
-[workspace]
-members = [ "parcel_sourcemap", "parcel_sourcemap_node", "parcel_sourcemap_wasm" ]

--- a/parcel_sourcemap/Cargo.toml
+++ b/parcel_sourcemap/Cargo.toml
@@ -8,11 +8,6 @@ license = "MIT"
 keywords = [ "sourcemap", "Node", "Parcel" ]
 repository = "https://github.com/parcel-bundler/source-map"
 
-[profile.release]
-lto = true
-opt-level = 3
-codegen-units = 1
-
 [dependencies]
 "vlq" = "0.5.1"
 "napi" = "1.6.1"

--- a/parcel_sourcemap_node/Cargo.toml
+++ b/parcel_sourcemap_node/Cargo.toml
@@ -7,11 +7,6 @@ edition = "2018"
 [lib]
 crate-type = ["cdylib"]
 
-[profile.release]
-lto = true
-opt-level = 3
-codegen-units = 1
-
 [dependencies]
 parcel_sourcemap = { path = "../parcel_sourcemap" }
 napi = { version = "1.6.1", features = ["napi4", "serde-json"] }

--- a/parcel_sourcemap_node/src/lib.rs
+++ b/parcel_sourcemap_node/src/lib.rs
@@ -4,8 +4,8 @@ extern crate napi_derive;
 extern crate parcel_sourcemap;
 
 use napi::{
-    CallContext, Either, Env, JsBuffer, JsNull, JsNumber, JsObject, JsString, JsUndefined,
-    Property, Result,
+    CallContext, Either, Env, JsBuffer, JsNull, JsNumber, JsObject, JsString, JsTypedArray,
+    JsUndefined, Property, Result,
 };
 use parcel_sourcemap::{Mapping, OriginalLocation, SourceMap};
 use serde_json::{from_str, to_string};
@@ -337,8 +337,15 @@ fn add_indexed_mappings(ctx: CallContext) -> Result<JsUndefined> {
     let this: JsObject = ctx.this_unchecked();
     let source_map_instance: &mut SourceMap = ctx.env.unwrap(&this)?;
 
-    let input = ctx.get::<JsString>(0)?.into_utf8()?;
-    let mappings_arr: Vec<i32> = from_str(input.as_str()?)?;
+    let mappings = ctx.get::<JsTypedArray>(0)?;
+    let mappings_value = mappings.into_value()?;
+    let mappings_slice = mappings_value.as_ref();
+    let mappings_arr: &[i32] = unsafe {
+        std::slice::from_raw_parts(
+            mappings_slice.as_ptr() as *const i32,
+            mappings_value.length as usize,
+        )
+    };
     let mappings_count = mappings_arr.len();
 
     let mut generated_line: u32 = 0; // 0

--- a/parcel_sourcemap_wasm/Cargo.toml
+++ b/parcel_sourcemap_wasm/Cargo.toml
@@ -4,10 +4,5 @@ version = "2.0.0-rc.2"
 authors = ["Jasper De Moor <jasperdemoor@gmail.com>"]
 edition = "2018"
 
-[profile.release]
-lto = true
-opt-level = 's' # optimize for size
-codegen-units = 1
-
 [dependencies]
 parcel_sourcemap = { path = "../parcel_sourcemap" }

--- a/src/SourceMap.js
+++ b/src/SourceMap.js
@@ -106,7 +106,7 @@ export default class SourceMap {
   ): Array<number> {
     // Encode all mappings into a single typed array and make one call
     // to C++ instead of one for each mapping to improve performance.
-    let mappingBuffer = [];
+    let mappingBuffer = new Int32Array(mappings.length * 6);
     let sources: Map<string, number> = new Map();
     let names: Map<string, number> = new Map();
     let i = 0;

--- a/src/node.js
+++ b/src/node.js
@@ -36,7 +36,7 @@ export default class NodeSourceMap extends SourceMap {
     columnOffset?: number = 0
   ): SourceMap {
     let mappingBuffer = this._indexedMappingsToInt32Array(mappings, lineOffset, columnOffset);
-    this.sourceMapInstance.addIndexedMappings(JSON.stringify(mappingBuffer));
+    this.sourceMapInstance.addIndexedMappings(mappingBuffer);
     return this;
   }
 


### PR DESCRIPTION
This uses typed arrays when adding indexed mappings again, but improves perf vs what's on master.

* master: 24,466 ops/s
* performance-improvements: 50,632 ops/s
* this pr: 113,351 ops/s

Also fixed the Cargo.toml config to put the profiles in the root rather than individual packages, otherwise it is ignored (there's a warning when building).