### PR TITLE
Use normal arrays + rkyv for improved perf

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,19 +3,16 @@
 version = 3
 
 [[package]]
+name = "autocfg"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+
+[[package]]
 name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
-
-[[package]]
-name = "bincode"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "bumpalo"
@@ -132,6 +129,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 
 [[package]]
+name = "memoffset"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "napi"
 version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -181,10 +187,9 @@ checksum = "af8b08b04175473088b46763e51ee54da5f9a164bc162f615b91bc179dbf15a3"
 name = "parcel_sourcemap"
 version = "2.0.0-rc.4"
 dependencies = [
- "bincode",
  "js-sys",
  "napi",
- "serde",
+ "rkyv",
  "vlq",
  "wasm-bindgen",
 ]
@@ -198,6 +203,7 @@ dependencies = [
  "napi-build",
  "napi-derive",
  "parcel_sourcemap",
+ "rkyv",
  "serde",
  "serde_json",
 ]
@@ -208,6 +214,7 @@ version = "2.0.0-rc.4"
 dependencies = [
  "js-sys",
  "parcel_sourcemap",
+ "rkyv",
  "serde",
  "wasm-bindgen",
 ]
@@ -225,6 +232,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0d8caf72986c1a598726adc988bb5984792ef84f5ee5aa50209145ee8077038"
 dependencies = [
  "unicode-xid",
+]
+
+[[package]]
+name = "ptr_meta"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7424255320182a46c403331afed6f95e0259a7c578f9da54a27e262ef3b60118"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53005b9863728f508d3f23ae37e03d60986a01b65f7ae8397dcebaa1d5e54e10"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -249,6 +276,29 @@ dependencies = [
  "untrusted",
  "web-sys",
  "winapi",
+]
+
+[[package]]
+name = "rkyv"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f10244dc3cf3eddbf33245a69d154620746c60f629bec071e236d135b654556d"
+dependencies = [
+ "memoffset",
+ "ptr_meta",
+ "rkyv_derive",
+ "seahash",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e3fccbf52ee0b76a29417794226e225798dd6bd32e40debd9e284cecc20dd76"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -279,6 +329,12 @@ dependencies = [
  "ring",
  "untrusted",
 ]
+
+[[package]]
+name = "seahash"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "serde"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,9 +280,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv"
-version = "0.6.6"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f10244dc3cf3eddbf33245a69d154620746c60f629bec071e236d135b654556d"
+checksum = "cb135b3e5e3311f0a254bfb00333f4bac9ef1d89888b84242a89eb8722b09a07"
 dependencies = [
  "memoffset",
  "ptr_meta",
@@ -292,9 +292,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv_derive"
-version = "0.6.3"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e3fccbf52ee0b76a29417794226e225798dd6bd32e40debd9e284cecc20dd76"
+checksum = "ba8f489f6b6d8551bb15904293c1ad58a6abafa7d8390d15f7ed05a2afcd87d5"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/parcel_sourcemap/Cargo.toml
+++ b/parcel_sourcemap/Cargo.toml
@@ -11,6 +11,6 @@ repository = "https://github.com/parcel-bundler/source-map"
 [dependencies]
 "vlq" = "0.5.1"
 "napi" = "1.6.1"
-rkyv = "0.6.6"
+rkyv = "0.6.7"
 "js-sys" = "0.3"
 "wasm-bindgen" = "0.2"

--- a/parcel_sourcemap/Cargo.toml
+++ b/parcel_sourcemap/Cargo.toml
@@ -11,7 +11,6 @@ repository = "https://github.com/parcel-bundler/source-map"
 [dependencies]
 "vlq" = "0.5.1"
 "napi" = "1.6.1"
-"serde" = { version = "1.0.126", features = ["derive"] }
-"bincode" = "1.3.3"
+rkyv = "0.6.6"
 "js-sys" = "0.3"
 "wasm-bindgen" = "0.2"

--- a/parcel_sourcemap/src/mapping.rs
+++ b/parcel_sourcemap/src/mapping.rs
@@ -1,6 +1,6 @@
-use serde::{Deserialize, Serialize};
+use rkyv::{Archive, Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, Debug, Clone, Copy)]
+#[derive(Archive, Serialize, Deserialize, Debug, Clone, Copy)]
 pub struct OriginalLocation {
     pub original_line: u32,
     pub original_column: u32,
@@ -19,7 +19,7 @@ impl OriginalLocation {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Archive, Serialize, Deserialize, Debug)]
 pub struct Mapping {
     pub generated_line: u32,
     pub generated_column: u32,

--- a/parcel_sourcemap/src/sourcemap_error.rs
+++ b/parcel_sourcemap/src/sourcemap_error.rs
@@ -116,7 +116,7 @@ impl From<SourceMapError> for napi::Error {
                 reason.push_str("Invalid FilePath");
             }
             SourceMapErrorType::BufferError => {
-                reason.push_str("Something went wrong while writing/reading a bincode buffer");
+                reason.push_str("Something went wrong while writing/reading a sourcemap buffer");
             }
             SourceMapErrorType::FromUtf8Error => {
                 reason.push_str("Could not convert utf-8 array to string");
@@ -171,7 +171,7 @@ impl From<SourceMapError> for wasm_bindgen::JsValue {
                 reason.push_str("Invalid FilePath");
             }
             SourceMapErrorType::BufferError => {
-                reason.push_str("Something went wrong while writing/reading a bincode buffer");
+                reason.push_str("Something went wrong while writing/reading a sourcemap buffer");
             }
             SourceMapErrorType::FromUtf8Error => {
                 reason.push_str("Could not convert utf-8 array to string");
@@ -189,9 +189,9 @@ impl From<SourceMapError> for wasm_bindgen::JsValue {
     }
 }
 
-impl From<std::boxed::Box<bincode::ErrorKind>> for SourceMapError {
+impl From<rkyv::Unreachable> for SourceMapError {
     #[inline]
-    fn from(_err: std::boxed::Box<bincode::ErrorKind>) -> SourceMapError {
+    fn from(_err: rkyv::Unreachable) -> SourceMapError {
         SourceMapError::new(SourceMapErrorType::BufferError)
     }
 }

--- a/parcel_sourcemap_node/Cargo.toml
+++ b/parcel_sourcemap_node/Cargo.toml
@@ -13,7 +13,7 @@ napi-derive = "1.1.0"
 parcel_sourcemap = {path = "../parcel_sourcemap"}
 serde = "1"
 serde_json = "1"
-rkyv = "0.6.6"
+rkyv = "0.6.7"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 jemallocator = {version = "0.3.2", features = ["disable_initial_exec_tls"]}

--- a/parcel_sourcemap_node/Cargo.toml
+++ b/parcel_sourcemap_node/Cargo.toml
@@ -13,6 +13,7 @@ napi-derive = "1.1.0"
 parcel_sourcemap = {path = "../parcel_sourcemap"}
 serde = "1"
 serde_json = "1"
+rkyv = "0.6.6"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 jemallocator = {version = "0.3.2", features = ["disable_initial_exec_tls"]}

--- a/parcel_sourcemap_wasm/Cargo.toml
+++ b/parcel_sourcemap_wasm/Cargo.toml
@@ -12,3 +12,4 @@ parcel_sourcemap = { path = "../parcel_sourcemap" }
 serde = { version = "1.0", features = ["derive"] }
 wasm-bindgen = { version = "0.2", features = ["serde-serialize"] }
 js-sys = "0.3"
+rkyv = "0.6.6"

--- a/parcel_sourcemap_wasm/Cargo.toml
+++ b/parcel_sourcemap_wasm/Cargo.toml
@@ -12,4 +12,4 @@ parcel_sourcemap = { path = "../parcel_sourcemap" }
 serde = { version = "1.0", features = ["derive"] }
 wasm-bindgen = { version = "0.2", features = ["serde-serialize"] }
 js-sys = "0.3"
-rkyv = "0.6.6"
+rkyv = "0.6.7"


### PR DESCRIPTION
This replaces bincode with [rkyv](https://github.com/djkoloski/rkyv), a very fast zero copy rust serialization/deserialization library. It's similar to flatbuffers but doesn't require a separate schema, and also faster.

This also removes the use of `BTreeMap` for storing line and column mappings. On profiles, inserting into the btree was taking a significant amount of time, and replacing with a flattened sorted array allowed for faster serialization/deserialization and didn't hurt offsetting too much. Also rkyv doesn't support serializing BTreeMap, so this was required in order to get the perf wins from that.

## Benchmarks

### BTreeMap

```
consume vlq mappings 130,782.8 opts/sec (mean: 0.008ms, stddev: 0.017ms, 5,000 samples)
consume 280,260.56 opts/sec (mean: 0.004ms, stddev: 0.011ms, 5,000 samples)
consume JS Mappings 122,756.29 opts/sec (mean: 0.008ms, stddev: 0.01ms, 5,000 samples)
addSourceMap 133,329.46 opts/sec (mean: 0.008ms, stddev: 0.014ms, 5,000 samples)
positive line offset 278,254.51 opts/sec (mean: 0.004ms, stddev: 0.012ms, 5,000 samples)
negative line offset 296,130.71 opts/sec (mean: 0.003ms, stddev: 0.007ms, 5,000 samples)
positive column offset 293,881.07 opts/sec (mean: 0.003ms, stddev: 0.007ms, 5,000 samples)
negative column offset 299,806.98 opts/sec (mean: 0.003ms, stddev: 0.008ms, 5,000 samples)
```

### Array

```
consume vlq mappings 156,300.09 opts/sec (mean: 0.006ms, stddev: 0.02ms, 5,000 samples)
consume 347,612.32 opts/sec (mean: 0.003ms, stddev: 0.009ms, 5,000 samples)
consume JS Mappings 151,189.25 opts/sec (mean: 0.007ms, stddev: 0.011ms, 5,000 samples)
addSourceMap 143,650.78 opts/sec (mean: 0.007ms, stddev: 0.011ms, 5,000 samples)
positive line offset 219,920.37 opts/sec (mean: 0.005ms, stddev: 0.009ms, 5,000 samples)
negative line offset 200,892.86 opts/sec (mean: 0.005ms, stddev: 0.011ms, 5,000 samples)
positive column offset 362,958.15 opts/sec (mean: 0.003ms, stddev: 0.004ms, 5,000 samples)
negative column offset 343,651.02 opts/sec (mean: 0.003ms, stddev: 0.009ms, 5,000 samples)
```

### Array + rkyv

```
consume vlq mappings 159,484.08 opts/sec (mean: 0.006ms, stddev: 0.02ms, 5,000 samples)
consume 743,793.16 opts/sec (mean: 0.001ms, stddev: 0.009ms, 5,000 samples)
consume JS Mappings 153,713.45 opts/sec (mean: 0.007ms, stddev: 0.01ms, 5,000 samples)
addSourceMap 226,616.87 opts/sec (mean: 0.004ms, stddev: 0.013ms, 5,000 samples)
positive line offset 297,294.78 opts/sec (mean: 0.003ms, stddev: 0.012ms, 5,000 samples)
negative line offset 324,412.19 opts/sec (mean: 0.003ms, stddev: 0.004ms, 5,000 samples)
positive column offset 695,686.24 opts/sec (mean: 0.001ms, stddev: 0.008ms, 5,000 samples)
negative column offset 706,491.6 opts/sec (mean: 0.001ms, stddev: 0.007ms, 5,000 samples)
```

### Overall

So ~2.5x faster for consuming buffer mappings, which was taking a majority of the time. On the esbuild benchmark this shaves off ~200ms from packaging, or ~20%.