### PR TITLE
Serialize to JSON from Rust instead of JS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,9 +187,12 @@ checksum = "af8b08b04175473088b46763e51ee54da5f9a164bc162f615b91bc179dbf15a3"
 name = "parcel_sourcemap"
 version = "2.0.0-rc.4"
 dependencies = [
+ "base64",
  "js-sys",
  "napi",
  "rkyv",
+ "serde",
+ "serde_json",
  "vlq",
  "wasm-bindgen",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,19 +3,16 @@
 version = 3
 
 [[package]]
+name = "autocfg"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+
+[[package]]
 name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
-
-[[package]]
-name = "bincode"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "bumpalo"
@@ -132,6 +129,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 
 [[package]]
+name = "memoffset"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "napi"
 version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -181,10 +187,9 @@ checksum = "af8b08b04175473088b46763e51ee54da5f9a164bc162f615b91bc179dbf15a3"
 name = "parcel_sourcemap"
 version = "2.0.0-rc.4"
 dependencies = [
- "bincode",
  "js-sys",
  "napi",
- "serde",
+ "rkyv",
  "vlq",
  "wasm-bindgen",
 ]
@@ -198,6 +203,7 @@ dependencies = [
  "napi-build",
  "napi-derive",
  "parcel_sourcemap",
+ "rkyv",
  "serde",
  "serde_json",
 ]
@@ -208,6 +214,7 @@ version = "2.0.0-rc.4"
 dependencies = [
  "js-sys",
  "parcel_sourcemap",
+ "rkyv",
  "serde",
  "wasm-bindgen",
 ]
@@ -225,6 +232,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0d8caf72986c1a598726adc988bb5984792ef84f5ee5aa50209145ee8077038"
 dependencies = [
  "unicode-xid",
+]
+
+[[package]]
+name = "ptr_meta"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7424255320182a46c403331afed6f95e0259a7c578f9da54a27e262ef3b60118"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53005b9863728f508d3f23ae37e03d60986a01b65f7ae8397dcebaa1d5e54e10"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -249,6 +276,29 @@ dependencies = [
  "untrusted",
  "web-sys",
  "winapi",
+]
+
+[[package]]
+name = "rkyv"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f10244dc3cf3eddbf33245a69d154620746c60f629bec071e236d135b654556d"
+dependencies = [
+ "memoffset",
+ "ptr_meta",
+ "rkyv_derive",
+ "seahash",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e3fccbf52ee0b76a29417794226e225798dd6bd32e40debd9e284cecc20dd76"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -279,6 +329,12 @@ dependencies = [
  "ring",
  "untrusted",
 ]
+
+[[package]]
+name = "seahash"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "serde"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,9 +280,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv"
-version = "0.6.6"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f10244dc3cf3eddbf33245a69d154620746c60f629bec071e236d135b654556d"
+checksum = "cb135b3e5e3311f0a254bfb00333f4bac9ef1d89888b84242a89eb8722b09a07"
 dependencies = [
  "memoffset",
  "ptr_meta",
@@ -292,9 +292,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv_derive"
-version = "0.6.3"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e3fccbf52ee0b76a29417794226e225798dd6bd32e40debd9e284cecc20dd76"
+checksum = "ba8f489f6b6d8551bb15904293c1ad58a6abafa7d8390d15f7ed05a2afcd87d5"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/parcel_sourcemap/Cargo.toml
+++ b/parcel_sourcemap/Cargo.toml
@@ -14,3 +14,6 @@ repository = "https://github.com/parcel-bundler/source-map"
 rkyv = "0.6.7"
 "js-sys" = "0.3"
 "wasm-bindgen" = "0.2"
+serde = {version = "1", features = ["derive"]}
+serde_json = "1"
+base64 = "0.13.0"

--- a/parcel_sourcemap/Cargo.toml
+++ b/parcel_sourcemap/Cargo.toml
@@ -11,6 +11,6 @@ repository = "https://github.com/parcel-bundler/source-map"
 [dependencies]
 "vlq" = "0.5.1"
 "napi" = "1.6.1"
-rkyv = "0.6.6"
+rkyv = "0.6.7"
 "js-sys" = "0.3"
 "wasm-bindgen" = "0.2"

--- a/parcel_sourcemap/Cargo.toml
+++ b/parcel_sourcemap/Cargo.toml
@@ -11,7 +11,6 @@ repository = "https://github.com/parcel-bundler/source-map"
 [dependencies]
 "vlq" = "0.5.1"
 "napi" = "1.6.1"
-"serde" = { version = "1.0.126", features = ["derive"] }
-"bincode" = "1.3.3"
+rkyv = "0.6.6"
 "js-sys" = "0.3"
 "wasm-bindgen" = "0.2"

--- a/parcel_sourcemap/src/lib.rs
+++ b/parcel_sourcemap/src/lib.rs
@@ -39,7 +39,7 @@ struct JSONSourceMap<'a> {
     mappings: String,
     sources: &'a Vec<String>,
     sources_content: &'a Vec<String>,
-    names: &'a Vec<String>
+    names: &'a Vec<String>,
 }
 
 impl SourceMap {
@@ -620,7 +620,11 @@ impl SourceMap {
         Ok(())
     }
 
-    pub fn write_to_json_buffer(&mut self, file: String, source_root: String) -> Result<Vec<u8>, SourceMapError> {
+    pub fn write_to_json_buffer(
+        &mut self,
+        file: String,
+        source_root: String,
+    ) -> Result<Vec<u8>, SourceMapError> {
         let mut vlq_output: Vec<u8> = vec![];
         self.write_vlq(&mut vlq_output)?;
 
@@ -638,10 +642,17 @@ impl SourceMap {
         Ok(buf)
     }
 
-    pub fn write_to_data_url(&mut self, file: String, source_root: String) -> Result<String, SourceMapError> {
+    pub fn write_to_data_url(
+        &mut self,
+        file: String,
+        source_root: String,
+    ) -> Result<String, SourceMapError> {
         let buf = self.write_to_json_buffer(file, source_root)?;
         let b64 = base64::encode(&buf);
-        Ok(format!("data:application/json;charset=utf-8;base64,{}", b64))
+        Ok(format!(
+            "data:application/json;charset=utf-8;base64,{}",
+            b64
+        ))
     }
 }
 

--- a/parcel_sourcemap/src/mapping.rs
+++ b/parcel_sourcemap/src/mapping.rs
@@ -1,6 +1,6 @@
-use serde::{Deserialize, Serialize};
+use rkyv::{Archive, Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, Debug, Clone, Copy)]
+#[derive(Archive, Serialize, Deserialize, Debug, Clone, Copy)]
 pub struct OriginalLocation {
     pub original_line: u32,
     pub original_column: u32,
@@ -19,7 +19,7 @@ impl OriginalLocation {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Archive, Serialize, Deserialize, Debug)]
 pub struct Mapping {
     pub generated_line: u32,
     pub generated_column: u32,

--- a/parcel_sourcemap/src/sourcemap_error.rs
+++ b/parcel_sourcemap/src/sourcemap_error.rs
@@ -37,6 +37,9 @@ pub enum SourceMapErrorType {
 
     // Failed to convert utf-8 to array
     FromUtf8Error = 11,
+
+    // Failed to serialize to JSON
+    JSONSerializeError = 12,
 }
 
 pub struct SourceMapError {
@@ -121,6 +124,9 @@ impl From<SourceMapError> for napi::Error {
             SourceMapErrorType::FromUtf8Error => {
                 reason.push_str("Could not convert utf-8 array to string");
             }
+            SourceMapErrorType::JSONSerializeError => {
+                reason.push_str("Error serializing to JSON");
+            }
         }
 
         // Add reason to error string if there is one
@@ -176,6 +182,9 @@ impl From<SourceMapError> for wasm_bindgen::JsValue {
             SourceMapErrorType::FromUtf8Error => {
                 reason.push_str("Could not convert utf-8 array to string");
             }
+            SourceMapErrorType::JSONSerializeError => {
+                reason.push_str("Error serializing to JSON");
+            }
         }
 
         // Add reason to error string if there is one
@@ -200,5 +209,12 @@ impl From<std::string::FromUtf8Error> for SourceMapError {
     #[inline]
     fn from(_err: std::string::FromUtf8Error) -> SourceMapError {
         SourceMapError::new(SourceMapErrorType::FromUtf8Error)
+    }
+}
+
+impl From<serde_json::Error> for SourceMapError {
+    #[inline]
+    fn from(_err: serde_json::Error) -> SourceMapError {
+        SourceMapError::new(SourceMapErrorType::JSONSerializeError)
     }
 }

--- a/parcel_sourcemap/src/sourcemap_error.rs
+++ b/parcel_sourcemap/src/sourcemap_error.rs
@@ -116,7 +116,7 @@ impl From<SourceMapError> for napi::Error {
                 reason.push_str("Invalid FilePath");
             }
             SourceMapErrorType::BufferError => {
-                reason.push_str("Something went wrong while writing/reading a bincode buffer");
+                reason.push_str("Something went wrong while writing/reading a sourcemap buffer");
             }
             SourceMapErrorType::FromUtf8Error => {
                 reason.push_str("Could not convert utf-8 array to string");
@@ -171,7 +171,7 @@ impl From<SourceMapError> for wasm_bindgen::JsValue {
                 reason.push_str("Invalid FilePath");
             }
             SourceMapErrorType::BufferError => {
-                reason.push_str("Something went wrong while writing/reading a bincode buffer");
+                reason.push_str("Something went wrong while writing/reading a sourcemap buffer");
             }
             SourceMapErrorType::FromUtf8Error => {
                 reason.push_str("Could not convert utf-8 array to string");
@@ -189,9 +189,9 @@ impl From<SourceMapError> for wasm_bindgen::JsValue {
     }
 }
 
-impl From<std::boxed::Box<bincode::ErrorKind>> for SourceMapError {
+impl From<rkyv::Unreachable> for SourceMapError {
     #[inline]
-    fn from(_err: std::boxed::Box<bincode::ErrorKind>) -> SourceMapError {
+    fn from(_err: rkyv::Unreachable) -> SourceMapError {
         SourceMapError::new(SourceMapErrorType::BufferError)
     }
 }

--- a/parcel_sourcemap_node/Cargo.toml
+++ b/parcel_sourcemap_node/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 napi = {version = "1.7.3", features = ["napi4", "serde-json"]}
 napi-derive = "1.1.0"
 parcel_sourcemap = {path = "../parcel_sourcemap"}
-serde = "1"
+serde = {version = "1", features = ["derive"]}
 serde_json = "1"
 rkyv = "0.6.7"
 

--- a/parcel_sourcemap_node/Cargo.toml
+++ b/parcel_sourcemap_node/Cargo.toml
@@ -13,7 +13,7 @@ napi-derive = "1.1.0"
 parcel_sourcemap = {path = "../parcel_sourcemap"}
 serde = "1"
 serde_json = "1"
-rkyv = "0.6.6"
+rkyv = "0.6.7"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 jemallocator = {version = "0.3.2", features = ["disable_initial_exec_tls"]}

--- a/parcel_sourcemap_node/Cargo.toml
+++ b/parcel_sourcemap_node/Cargo.toml
@@ -13,6 +13,7 @@ napi-derive = "1.1.0"
 parcel_sourcemap = {path = "../parcel_sourcemap"}
 serde = "1"
 serde_json = "1"
+rkyv = "0.6.6"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 jemallocator = {version = "0.3.2", features = ["disable_initial_exec_tls"]}

--- a/parcel_sourcemap_node/src/lib.rs
+++ b/parcel_sourcemap_node/src/lib.rs
@@ -322,6 +322,40 @@ fn to_vlq(ctx: CallContext) -> Result<JsObject> {
     Ok(result_obj)
 }
 
+#[js_function(2)]
+fn to_json_buffer(ctx: CallContext) -> Result<JsBuffer> {
+    let this: JsObject = ctx.this_unchecked();
+    let source_map_instance: &mut SourceMap = ctx.env.unwrap(&this)?;
+
+    let file = ctx.get::<JsString>(0)?.into_utf8()?;
+    let source_root = ctx.get::<JsString>(1)?.into_utf8()?;
+
+    let buf = source_map_instance.write_to_json_buffer(
+        file.as_str()?.to_string(),
+        source_root.as_str()?.to_string()
+    )?;
+
+    let buffer = ctx.env.create_buffer_with_data(buf)?.into_raw();
+    Ok(buffer)
+}
+
+#[js_function(2)]
+fn to_data_url(ctx: CallContext) -> Result<JsString> {
+    let this: JsObject = ctx.this_unchecked();
+    let source_map_instance: &mut SourceMap = ctx.env.unwrap(&this)?;
+
+    let file = ctx.get::<JsString>(0)?.into_utf8()?;
+    let source_root = ctx.get::<JsString>(1)?.into_utf8()?;
+
+    let string = source_map_instance.write_to_data_url(
+        file.as_str()?.to_string(),
+        source_root.as_str()?.to_string()
+    )?;
+
+    let s = ctx.env.create_string(&string)?;
+    Ok(s)
+}
+
 #[js_function(1)]
 fn add_indexed_mappings(ctx: CallContext) -> Result<JsUndefined> {
     let this: JsObject = ctx.this_unchecked();
@@ -495,6 +529,8 @@ fn init(mut exports: JsObject, env: Env) -> Result<()> {
         Property::new(&env, "addIndexedMappings")?.with_method(add_indexed_mappings);
     let add_vlq_map_method = Property::new(&env, "addVLQMap")?.with_method(add_vlq_map);
     let to_vlq_method = Property::new(&env, "toVLQ")?.with_method(to_vlq);
+    let to_json_buffer_method = Property::new(&env, "toJSONBuffer")?.with_method(to_json_buffer);
+    let to_data_url_method = Property::new(&env, "toDataURL")?.with_method(to_data_url);
     let offset_lines_method = Property::new(&env, "offsetLines")?.with_method(offset_lines);
     let offset_columns_method = Property::new(&env, "offsetColumns")?.with_method(offset_columns);
     let add_empty_map_method = Property::new(&env, "addEmptyMap")?.with_method(add_empty_map);
@@ -524,6 +560,8 @@ fn init(mut exports: JsObject, env: Env) -> Result<()> {
             add_vlq_map_method,
             to_buffer_method,
             to_vlq_method,
+            to_json_buffer_method,
+            to_data_url_method,
             offset_lines_method,
             offset_columns_method,
             add_empty_map_method,

--- a/parcel_sourcemap_node/src/lib.rs
+++ b/parcel_sourcemap_node/src/lib.rs
@@ -332,7 +332,7 @@ fn to_json_buffer(ctx: CallContext) -> Result<JsBuffer> {
 
     let buf = source_map_instance.write_to_json_buffer(
         file.as_str()?.to_string(),
-        source_root.as_str()?.to_string()
+        source_root.as_str()?.to_string(),
     )?;
 
     let buffer = ctx.env.create_buffer_with_data(buf)?.into_raw();
@@ -349,7 +349,7 @@ fn to_data_url(ctx: CallContext) -> Result<JsString> {
 
     let string = source_map_instance.write_to_data_url(
         file.as_str()?.to_string(),
-        source_root.as_str()?.to_string()
+        source_root.as_str()?.to_string(),
     )?;
 
     let s = ctx.env.create_string(&string)?;

--- a/parcel_sourcemap_wasm/Cargo.toml
+++ b/parcel_sourcemap_wasm/Cargo.toml
@@ -12,3 +12,4 @@ parcel_sourcemap = { path = "../parcel_sourcemap" }
 serde = { version = "1.0", features = ["derive"] }
 wasm-bindgen = { version = "0.2", features = ["serde-serialize"] }
 js-sys = "0.3"
+rkyv = "0.6.6"

--- a/parcel_sourcemap_wasm/Cargo.toml
+++ b/parcel_sourcemap_wasm/Cargo.toml
@@ -12,4 +12,4 @@ parcel_sourcemap = { path = "../parcel_sourcemap" }
 serde = { version = "1.0", features = ["derive"] }
 wasm-bindgen = { version = "0.2", features = ["serde-serialize"] }
 js-sys = "0.3"
-rkyv = "0.6.6"
+rkyv = "0.6.7"

--- a/parcel_sourcemap_wasm/src/lib.rs
+++ b/parcel_sourcemap_wasm/src/lib.rs
@@ -115,6 +115,16 @@ impl SourceMap {
         Ok(JsValue::from_serde(&result).unwrap())
     }
 
+    pub fn toJSONBuffer(&mut self, file: String, source_root: String) -> Result<JsValue, JsValue> {
+        let buf = self.map.write_to_json_buffer(file, source_root)?;
+        Ok(Uint8Array::from(buf.as_slice()).into())
+    }
+
+    pub fn toDataURL(&mut self, file: String, source_root: String) -> Result<JsValue, JsValue> {
+        let string = self.map.write_to_data_url(file, source_root)?;
+        Ok(JsValue::from(string))
+    }
+
     pub fn getMappings(&self) -> Result<JsValue, JsValue> {
         let mut mappings: Vec<MappingResult> = vec![];
         for (generated_line, mapping_line) in self.map.mapping_lines.iter().enumerate() {

--- a/src/SourceMap.js
+++ b/src/SourceMap.js
@@ -441,4 +441,12 @@ export default class SourceMap {
       rootDir: this.projectRoot || options.rootDir,
     });
   }
+
+  toJSONBuffer(file: string, sourceRoot: string): Buffer {
+    return this.sourceMapInstance.toJSONBuffer(file, sourceRoot);
+  }
+
+  toDataURL(file: string, sourceRoot: string): Buffer {
+    return this.sourceMapInstance.toDataURL(file, sourceRoot);
+  }
 }


### PR DESCRIPTION
Depends on #67.

`partialVlqMapToSourceMap` was taking almost 100ms on the esbuild benchmark. This moves the JSON serialization and data URL construction logic into Rust, which reduces the time to ~40ms.

I've split it into two separate methods, one which returns a JSON Buffer (faster than converting to a string when we can write it straight to the cache without copying), and one which returns a data url as a string.

Comparison:

```
stringify 140,625.33 opts/sec (mean: 0.007ms, stddev: 0.015ms, 5,000 samples)
toJSONBuffer 357,935.68 opts/sec (mean: 0.003ms, stddev: 0.009ms, 5,000 samples)
stringify inline 117,713.53 opts/sec (mean: 0.008ms, stddev: 0.017ms, 5,000 samples)
toDataURL 426,911.55 opts/sec (mean: 0.002ms, stddev: 0.004ms, 5,000 samples)
```

The current stringify method does a bunch of other things though, which I'm not sure if we need.

* Replaces empty strings in `sourcesContent` with null. We could possibly do this in Rust but I want to understand why this is needed.
* Makes the `sourcesContent` array the same length as the `sources` array by appending nulls. Again, why is this needed?
* Reads `sourcesContent` from the file system if not provided. IMO this should be done in Parcel core, if at all. I think we now set the sourcesContent during transformation for most assets now.
* The `inlineSources` option - since we are adding sourcesContent during transformation for most assets, is this needed anymore? How would we know whether to remove the source content from the sourcemap because it's available on disk or not?
* Apparently `stringify` can also return an object representation, which seems weird. Maybe `toVLQ` is good enough for this?

@DeMoorJasper what do you think?