### PR TITLE
Don't include project root in serialized buffers

### DIFF
--- a/bench/consume.js
+++ b/bench/consume.js
@@ -34,7 +34,7 @@ exports.consume = function () {
       map.delete();
     }),
     b.add('consume buffer', () => {
-      let map = new SourceMap(sourcemapBuffer);
+      let map = new SourceMap('/', sourcemapBuffer);
       map.delete();
     }),
     b.add('consume JS Mappings', () => {

--- a/parcel_sourcemap_node/build.js
+++ b/parcel_sourcemap_node/build.js
@@ -35,8 +35,8 @@ async function build() {
 // This forces Clang/LLVM to be used as a C compiler instead of GCC.
 // This is necessary for cross-compilation for Apple Silicon in GitHub Actions.
 function setupMacBuild() {
-  process.env.CC = execSync('xcrun -f clang', {encoding: 'utf8'}).trim();
-  process.env.CXX = execSync('xcrun -f clang++', {encoding: 'utf8'}).trim();
+  process.env.CC = execSync('xcrun -f clang', { encoding: 'utf8' }).trim();
+  process.env.CXX = execSync('xcrun -f clang++', { encoding: 'utf8' }).trim();
 
   let sysRoot = execSync('xcrun --sdk macosx --show-sdk-path', {
     encoding: 'utf8',

--- a/src/SourceMap.js
+++ b/src/SourceMap.js
@@ -21,7 +21,7 @@ export default class SourceMap {
    *
    * @param projectRoot root directory of the project, this is to ensure all source paths are relative to this path
    */
-  constructor(opts: string | Buffer = '/') {}
+  constructor(projectRoot: string = '/', buffer?: Buffer) {}
 
   // Use this to invalidate saved buffers, we don't check versioning at all in Rust
   get libraryVersion(): string {

--- a/src/node.js
+++ b/src/node.js
@@ -6,10 +6,10 @@ import SourceMap from './SourceMap';
 const bindings = require('../parcel_sourcemap_node/index');
 
 export default class NodeSourceMap extends SourceMap {
-  constructor(opts: string | Buffer = '/') {
-    super(opts);
-    this.sourceMapInstance = new bindings.SourceMap(opts);
-    this.projectRoot = this.sourceMapInstance.getProjectRoot();
+  constructor(projectRoot: string = '/', buffer?: Buffer) {
+    super(projectRoot);
+    this.projectRoot = projectRoot;
+    this.sourceMapInstance = new bindings.SourceMap(projectRoot, buffer);
   }
 
   addVLQMap(map: VLQMap, lineOffset: number = 0, columnOffset: number = 0): SourceMap {
@@ -40,13 +40,13 @@ export default class NodeSourceMap extends SourceMap {
   }
 
   addBuffer(buffer: Buffer, lineOffset: number = 0): SourceMap {
-    let previousMap = new NodeSourceMap(buffer);
+    let previousMap = new NodeSourceMap(this.projectRoot, buffer);
     return this.addSourceMap(previousMap, lineOffset);
   }
 
   extends(input: Buffer | SourceMap): SourceMap {
     // $FlowFixMe
-    let inputSourceMap: SourceMap = Buffer.isBuffer(input) ? new NodeSourceMap(input) : input;
+    let inputSourceMap: SourceMap = Buffer.isBuffer(input) ? new NodeSourceMap(this.projectRoot, input) : input;
     this.sourceMapInstance.extends(inputSourceMap.sourceMapInstance);
     return this;
   }

--- a/src/wasm.js
+++ b/src/wasm.js
@@ -8,9 +8,9 @@ import * as bindings from './wasm-bindings';
 export const init: Promise<void> = typeof bindings.init === 'function' ? bindings.init() : Promise.resolve();
 
 export default class WasmSourceMap extends SourceMap {
-  constructor(opts: string | Buffer = '/') {
-    super(opts);
-    this.sourceMapInstance = new bindings.SourceMap(opts);
+  constructor(projectRoot: string = '/', buffer?: Buffer) {
+    super(projectRoot, buffer);
+    this.sourceMapInstance = new bindings.SourceMap(projectRoot, buffer);
     this.projectRoot = this.sourceMapInstance.getProjectRoot();
   }
 
@@ -42,13 +42,13 @@ export default class WasmSourceMap extends SourceMap {
   }
 
   addBuffer(buffer: Buffer, lineOffset: number = 0): SourceMap {
-    let previousMap = new WasmSourceMap(buffer);
+    let previousMap = new WasmSourceMap(this.projectRoot, buffer);
     return this.addSourceMap(previousMap, lineOffset);
   }
 
   extends(input: Buffer | SourceMap): SourceMap {
     // $FlowFixMe
-    let inputSourceMap: SourceMap = input instanceof Uint8Array ? new WasmSourceMap(input) : input;
+    let inputSourceMap: SourceMap = input instanceof Uint8Array ? new WasmSourceMap(this.projectRoot, input) : input;
     this.sourceMapInstance.extends(inputSourceMap.sourceMapInstance);
     return this;
   }

--- a/test/append.test.js
+++ b/test/append.test.js
@@ -265,7 +265,7 @@ describe('SourceMap - Append Mappings', () => {
       sources: SIMPLE_SOURCE_MAP.sources,
       names: SIMPLE_SOURCE_MAP.names,
     });
-    let map2 = new SourceMap(map.toBuffer());
+    let map2 = new SourceMap('/test-root', map.toBuffer());
     map.addSourceMap(map2, 10);
     assert.deepEqual(map.getMap(), expectedResultOne);
     // map2 is consumed


### PR DESCRIPTION
Related to https://github.com/parcel-bundler/parcel/pull/5900

This splits the SourceMap struct into two: one that will be archived and stored in the cache, and a wrapper that the API works with. Only the wrapper includes the project root. This way, the absolute project root path won't get written into the cache. The API now always requires the project root argument to the constructor, and the buffer is an optional second argument.