### PR TITLE
fix: Properly remap source_content to source_index

### DIFF
--- a/parcel_sourcemap/src/lib.rs
+++ b/parcel_sourcemap/src/lib.rs
@@ -529,7 +529,9 @@ impl SourceMap {
 
         self.inner.sources_content.reserve(sources_content.len());
         for (i, source_content) in sources_content.iter().enumerate() {
-            self.set_source_content(i, source_content)?;
+            if let Some(source_index) = source_indexes.get(i) {
+                self.set_source_content(*source_index as usize, source_content)?;
+            }
         }
 
         let mut input = input.iter().cloned().peekable();

--- a/parcel_sourcemap/src/lib.rs
+++ b/parcel_sourcemap/src/lib.rs
@@ -238,15 +238,11 @@ impl SourceMap {
 
     pub fn get_source_index(&self, source: &str) -> Option<u32> {
         let normalized_source = make_relative_path(self.project_root.as_str(), source);
-        match self
-            .inner
+        self.inner
             .sources
             .iter()
             .position(|s| normalized_source.eq(s))
-        {
-            Some(i) => Some(i as u32),
-            None => None,
-        }
+            .map(|v| v as u32)
     }
 
     pub fn get_source(&self, index: u32) -> Result<&str, SourceMapError> {

--- a/parcel_sourcemap/src/lib.rs
+++ b/parcel_sourcemap/src/lib.rs
@@ -236,13 +236,14 @@ impl SourceMap {
         result_vec
     }
 
-    pub fn get_source_index(&self, source: &str) -> Option<u32> {
+    pub fn get_source_index(&self, source: &str) -> Result<Option<u32>, SourceMapError> {
         let normalized_source = make_relative_path(self.project_root.as_str(), source);
-        self.inner
+        Ok(self
+            .inner
             .sources
             .iter()
             .position(|s| normalized_source.eq(s))
-            .map(|v| v as u32)
+            .map(|v| v as u32))
     }
 
     pub fn get_source(&self, index: u32) -> Result<&str, SourceMapError> {

--- a/parcel_sourcemap/src/lib.rs
+++ b/parcel_sourcemap/src/lib.rs
@@ -236,7 +236,7 @@ impl SourceMap {
         result_vec
     }
 
-    pub fn get_source_index(&self, source: &str) -> Result<Option<u32>, SourceMapError> {
+    pub fn get_source_index(&self, source: &str) -> Option<u32> {
         let normalized_source = make_relative_path(self.project_root.as_str(), source);
         match self
             .inner
@@ -244,8 +244,8 @@ impl SourceMap {
             .iter()
             .position(|s| normalized_source.eq(s))
         {
-            Some(i) => Ok(Some(i as u32)),
-            None => Ok(None),
+            Some(i) => Some(i as u32),
+            None => None,
         }
     }
 

--- a/parcel_sourcemap_node/src/lib.rs
+++ b/parcel_sourcemap_node/src/lib.rs
@@ -94,8 +94,7 @@ fn get_source_index(ctx: CallContext) -> Result<JsNumber> {
     let source_map_instance: &SourceMap = ctx.env.unwrap(&this)?;
 
     let source = ctx.get::<JsString>(0)?.into_utf8()?;
-    let source_index = source_map_instance.get_source_index(source.as_str()?);
-
+    let source_index = source_map_instance.get_source_index(source.as_str()?)?;
     match source_index {
         Some(i) => ctx.env.create_uint32(i),
         None => ctx.env.create_int32(-1),
@@ -121,7 +120,7 @@ fn get_source_content_by_source(ctx: CallContext) -> Result<JsString> {
     let source_map_instance: &mut SourceMap = ctx.env.unwrap(&this)?;
 
     let source = ctx.get::<JsString>(0)?.into_utf8()?;
-    let source_index = source_map_instance.get_source_index(source.as_str()?);
+    let source_index = source_map_instance.get_source_index(source.as_str()?)?;
     match source_index {
         Some(i) => {
             let source_content = source_map_instance.get_source_content(i)?;

--- a/parcel_sourcemap_node/src/lib.rs
+++ b/parcel_sourcemap_node/src/lib.rs
@@ -94,7 +94,7 @@ fn get_source_index(ctx: CallContext) -> Result<JsNumber> {
     let source_map_instance: &SourceMap = ctx.env.unwrap(&this)?;
 
     let source = ctx.get::<JsString>(0)?.into_utf8()?;
-    let source_index = source_map_instance.get_source_index(source.as_str()?)?;
+    let source_index = source_map_instance.get_source_index(source.as_str()?);
 
     match source_index {
         Some(i) => ctx.env.create_uint32(i),
@@ -121,7 +121,7 @@ fn get_source_content_by_source(ctx: CallContext) -> Result<JsString> {
     let source_map_instance: &mut SourceMap = ctx.env.unwrap(&this)?;
 
     let source = ctx.get::<JsString>(0)?.into_utf8()?;
-    let source_index = source_map_instance.get_source_index(source.as_str()?)?;
+    let source_index = source_map_instance.get_source_index(source.as_str()?);
     match source_index {
         Some(i) => {
             let source_content = source_map_instance.get_source_content(i)?;

--- a/parcel_sourcemap_wasm/src/lib.rs
+++ b/parcel_sourcemap_wasm/src/lib.rs
@@ -173,7 +173,7 @@ impl SourceMap {
     }
 
     pub fn getSourceIndex(&self, source: &str) -> Result<JsValue, JsValue> {
-        let mapped_val: i32 = match self.map.get_source_index(source) {
+        let mapped_val: i32 = match self.map.get_source_index(source)? {
             Some(found_source_index) => i32::try_from(found_source_index).unwrap_or(-1),
             None => -1,
         };
@@ -256,8 +256,7 @@ impl SourceMap {
     }
 
     pub fn getSourceContentBySource(&self, source: &str) -> Result<JsValue, JsValue> {
-        let source_index = self.map.get_source_index(source);
-
+        let source_index = self.map.get_source_index(source)?;
         match source_index {
             Some(i) => {
                 let source_content = self.map.get_source_content(i)?;

--- a/parcel_sourcemap_wasm/src/lib.rs
+++ b/parcel_sourcemap_wasm/src/lib.rs
@@ -173,10 +173,10 @@ impl SourceMap {
     }
 
     pub fn getSourceIndex(&self, source: &str) -> Result<JsValue, JsValue> {
-        let mut mapped_val: i32 = -1;
-        if let Some(found_source_index) = self.map.get_source_index(source) {
-            mapped_val = i32::try_from(found_source_index).unwrap_or(-1);
-        }
+        let mapped_val: i32 = match self.map.get_source_index(source) {
+            Some(found_source_index) => i32::try_from(found_source_index).unwrap_or(-1),
+            None => -1,
+        };
         Ok(JsValue::from(mapped_val))
     }
 

--- a/parcel_sourcemap_wasm/src/lib.rs
+++ b/parcel_sourcemap_wasm/src/lib.rs
@@ -173,12 +173,8 @@ impl SourceMap {
     }
 
     pub fn getSourceIndex(&self, source: &str) -> Result<JsValue, JsValue> {
-        Ok(JsValue::from(
-            self.map
-                .get_source_index(source)?
-                .map(|v| i32::try_from(v).unwrap())
-                .unwrap_or(-1),
-        ))
+        let mapped_val: i32 = i32::try_from(self.map.get_source_index(source)).unwrap_or(-1);
+        Ok(JsValue::from(mapped_val))
     }
 
     pub fn addIndexedMappings(&mut self, mappings_arr: &[i32]) {
@@ -257,7 +253,7 @@ impl SourceMap {
     }
 
     pub fn getSourceContentBySource(&self, source: &str) -> Result<JsValue, JsValue> {
-        let source_index = self.map.get_source_index(source)?;
+        let source_index = self.map.get_source_index(source);
 
         match source_index {
             Some(i) => {

--- a/parcel_sourcemap_wasm/src/lib.rs
+++ b/parcel_sourcemap_wasm/src/lib.rs
@@ -173,7 +173,10 @@ impl SourceMap {
     }
 
     pub fn getSourceIndex(&self, source: &str) -> Result<JsValue, JsValue> {
-        let mapped_val: i32 = i32::try_from(self.map.get_source_index(source)).unwrap_or(-1);
+        let mut mapped_val: i32 = -1;
+        if let Some(found_source_index) = self.map.get_source_index(source) {
+            mapped_val = i32::try_from(found_source_index).unwrap_or(-1);
+        }
         Ok(JsValue::from(mapped_val))
     }
 

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -410,7 +410,7 @@ describe('SourceMap - Basics', () => {
     assert.equal(map.getSourceContent('helloworld.coffee'), 'module.exports = () => "hello world";');
   });
 
-  it('Should deduplicate sources and sources_content', () => {
+  it('Should deduplicate sources and sourcesContent from a VLQ Map', () => {
     let map = new SourceMap('/test-root');
     map.addVLQMap({
       mappings: SIMPLE_SOURCE_MAP.mappings,

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -249,7 +249,7 @@ describe('SourceMap - Basics', () => {
     assert.deepEqual(map.addSources(['test.js', 'execute.js']), [2, 3]);
 
     assert.deepEqual(map.addSource('abc.js'), 4);
-    assert.deepEqual(map.addSource("dist/rörfokus/4784.js"), 5);
+    assert.deepEqual(map.addSource('dist/rörfokus/4784.js'), 5);
   });
 
   it('Should be able to handle absolute url sources', () => {
@@ -408,5 +408,21 @@ describe('SourceMap - Basics', () => {
     });
 
     assert.equal(map.getSourceContent('helloworld.coffee'), 'module.exports = () => "hello world";');
+  });
+
+  it('Should deduplicate sources and sources_content', () => {
+    let map = new SourceMap('/test-root');
+    map.addVLQMap({
+      mappings: SIMPLE_SOURCE_MAP.mappings,
+      sources: ['./index.js', './index.js'],
+      sourcesContent: ['first', 'second'],
+      names: ['a'],
+    });
+
+    const stringifiedMap = map.toVLQ();
+    assert.equal(stringifiedMap.mappings, SIMPLE_SOURCE_MAP.mappings);
+    assert.deepEqual(stringifiedMap.sources, ['index.js']);
+    assert.deepEqual(stringifiedMap.sourcesContent, ['second']);
+    assert.deepEqual(stringifiedMap.names, ['a']);
   });
 });


### PR DESCRIPTION
Apparently forgot to remap sources_content indexes to source indexes in `add_vlq_map`, surprised this didn't come up earlier.

Also found a small thing that could be improved while debugging this

Closes #86 