### PR TITLE
Revert "feat(parcel_sourcemap_node): upgrade to napi-rs v2"

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -46,3 +46,4 @@ jobs:
         run: |
           cargo install cargo-cache --no-default-features --features ci-autoclean
           cargo-cache
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,16 +9,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
-name = "bumpalo"
-version = "3.9.0"
+name = "base64"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe438c9d2f2b0fb88a112154ed81e30b0a491c29322afe1db3b6eec5811f5ba0"
+checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+
+[[package]]
+name = "bumpalo"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63396b8a4b9de3f4fdfb320ab6080762242f66a8ef174c49d8e19b674db4cdbe"
 
 [[package]]
 name = "cc"
-version = "1.0.72"
+version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22a9137b95ea06864e018375b72adfb7db6e6f68cfc8df5a04d00288050485ee"
+checksum = "e3c69b077ad434294d3ce9f1f6143a2a4b89a8a2d54ef813d85003a4fd1137fd"
 
 [[package]]
 name = "cfg-if"
@@ -27,28 +33,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "convert_case"
-version = "0.4.0"
+name = "chunked_transfer"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+checksum = "fff857943da45f546682664a79488be82e69e43c1a7a2307679ab9afb3a66d2e"
 
 [[package]]
-name = "ctor"
-version = "0.1.21"
+name = "form_urlencoded"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccc0a48a9b826acdf4028595adc9db92caea352f7af011a3034acd172a52a0aa"
+checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
 dependencies = [
- "quote",
- "syn",
-]
-
-[[package]]
-name = "encoding_rs"
-version = "0.8.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7896dc8abb250ffdda33912550faa54c88ec8b998dec0b2c55ab224921ce11df"
-dependencies = [
- "cfg-if",
+ "matches",
+ "percent-encoding",
 ]
 
 [[package]]
@@ -58,10 +55,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2022715d62ab30faffd124d40b76f4134a550a87792276512b18d63272333394"
 
 [[package]]
-name = "itoa"
-version = "1.0.1"
+name = "idna"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
+checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
+dependencies = [
+ "matches",
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "itoa"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "jemalloc-sys"
@@ -86,9 +94,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.55"
+version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cc9ffccd38c451a86bf13657df244e9c3f37493cce8e5e21e940963777acc84"
+checksum = "83bdfbace3a0e81a4253f73b49e960b053e396a11012cbd49b9b74d6a2b67062"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -101,9 +109,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.112"
+version = "0.2.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125"
+checksum = "18794a8ad5b29321f790b55d93dfba91e125cb1a9edbd4f8e3150acc771c1a5e"
 
 [[package]]
 name = "log"
@@ -115,55 +123,49 @@ dependencies = [
 ]
 
 [[package]]
-name = "memoffset"
-version = "0.6.5"
+name = "matches"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
+
+[[package]]
+name = "memoffset"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
 dependencies = [
  "autocfg",
 ]
 
 [[package]]
 name = "napi"
-version = "2.0.2"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4cfe7fef533df6323a5aa17d75cb162850f2b045adabb9922bfbd234426a1bb"
+checksum = "650d066af7b13cf35f0a84e89c7c652c566c0c38c7c1d63857e27b0b9a443c59"
 dependencies = [
- "ctor",
- "encoding_rs",
- "lazy_static",
+ "napi-build",
  "napi-sys",
  "serde",
  "serde_json",
- "windows",
+ "winapi",
 ]
 
 [[package]]
 name = "napi-build"
-version = "1.2.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebd4419172727423cf30351406c54f6cc1b354a2cfb4f1dba3e6cd07f6d5522b"
-
-[[package]]
-name = "napi-derive"
-version = "2.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08c0f7a63a6f6d47255ab90a3048b64659671648c69b4a208374f481b0c26173"
+checksum = "3039ed15066300360660239cab9a6071a0ed899547c49e40952d87ded49b29b8"
 dependencies = [
- "convert_case",
- "napi-derive-backend",
- "proc-macro2",
- "quote",
- "syn",
+ "cfg-if",
+ "ureq",
 ]
 
 [[package]]
-name = "napi-derive-backend"
-version = "1.0.21"
+name = "napi-derive"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "487c39117657211e9bf93acade9363eac61ceead142e4906d15ff08d29fa448d"
+checksum = "8e7ed160148f94ee17936f00288029cb0cfb37c08bbace9f514f735dcd869ed7"
 dependencies = [
- "convert_case",
  "proc-macro2",
  "quote",
  "syn",
@@ -171,17 +173,22 @@ dependencies = [
 
 [[package]]
 name = "napi-sys"
-version = "2.1.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a385494dac3c52cbcacb393bb3b42669e7db8ab240c7ad5115f549eb061f2cc"
+checksum = "192c38c1012409fbf1d9868e29375fc3e1444cf1e222ba407c7bca6a2187fbfa"
+
+[[package]]
+name = "once_cell"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af8b08b04175473088b46763e51ee54da5f9a164bc162f615b91bc179dbf15a3"
 
 [[package]]
 name = "parcel_sourcemap"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "js-sys",
  "napi",
- "napi-derive",
  "rkyv",
  "vlq",
  "wasm-bindgen",
@@ -213,28 +220,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.36"
+name = "percent-encoding"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
+checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8caf72986c1a598726adc988bb5984792ef84f5ee5aa50209145ee8077038"
 dependencies = [
  "unicode-xid",
 ]
 
 [[package]]
 name = "ptr_meta"
-version = "0.1.4"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
+checksum = "7424255320182a46c403331afed6f95e0259a7c578f9da54a27e262ef3b60118"
 dependencies = [
  "ptr_meta_derive",
 ]
 
 [[package]]
 name = "ptr_meta_derive"
-version = "0.1.4"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
+checksum = "53005b9863728f508d3f23ae37e03d60986a01b65f7ae8397dcebaa1d5e54e10"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -243,11 +256,26 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.14"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47aa80447ce4daf1717500037052af176af5d38cc3e571d9ec1c7353fc10c87d"
+checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "ring"
+version = "0.16.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+dependencies = [
+ "cc",
+ "libc",
+ "once_cell",
+ "spin",
+ "untrusted",
+ "web-sys",
+ "winapi",
 ]
 
 [[package]]
@@ -274,10 +302,33 @@ dependencies = [
 ]
 
 [[package]]
-name = "ryu"
-version = "1.0.9"
+name = "rustls"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
+checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
+dependencies = [
+ "base64",
+ "log",
+ "ring",
+ "sct",
+ "webpki",
+]
+
+[[package]]
+name = "ryu"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+
+[[package]]
+name = "sct"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "seahash"
@@ -287,18 +338,18 @@ checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "serde"
-version = "1.0.133"
+version = "1.0.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97565067517b60e2d1ea8b268e59ce036de907ac523ad83a0475da04e818989a"
+checksum = "ec7505abeacaec74ae4778d9d9328fe5a5d04253220a85c4ee022239fc996d03"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.133"
+version = "1.0.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed201699328568d8d08208fdd080e3ff594e6c422e438b6705905da01005d537"
+checksum = "963a7dbc9895aeac7ac90e74f34a5d5261828f79df35cbed41e10189d3804d43"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -307,9 +358,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.74"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee2bb9cd061c5865d345bb02ca49fcef1391741b672b54a0bf7b679badec3142"
+checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
 dependencies = [
  "itoa",
  "ryu",
@@ -317,14 +368,53 @@ dependencies = [
 ]
 
 [[package]]
-name = "syn"
-version = "1.0.85"
+name = "spin"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a684ac3dcd8913827e18cd09a68384ee66c1de24157e3c556c9ab16d85695fb7"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "syn"
+version = "1.0.72"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1e8cdbefb79a9a5a65e0db8b47b723ee907b7c7f8496c76a1770b5c310bab82"
 dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b5220f05bb7de7f3f53c7c065e1199b3172696fe2db9f9c4d8ad9b4ee74c342"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeb8be209bb1c96b7c177c7420d26e04eccacb0eeae6b980e35fcb74678107e0"
+dependencies = [
+ "matches",
+]
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07fbfce1c8a97d547e8b5334978438d9d6ec8c20e38f56d4a4374d181493eaef"
+dependencies = [
+ "tinyvec",
 ]
 
 [[package]]
@@ -334,6 +424,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "ureq"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2475a6781e9bc546e7b64f4013d2f4032c8c6a40fcffd7c6f4ee734a890972ab"
+dependencies = [
+ "base64",
+ "chunked_transfer",
+ "log",
+ "once_cell",
+ "rustls",
+ "url",
+ "webpki",
+ "webpki-roots",
+]
+
+[[package]]
+name = "url"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "matches",
+ "percent-encoding",
+]
+
+[[package]]
 name = "vlq"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -341,9 +465,9 @@ checksum = "65dd7eed29412da847b0f78bcec0ac98588165988a8cfe41d4ea1d429f8ccfff"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.78"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "632f73e236b219150ea279196e54e610f5dbafa5d61786303d4da54f84e47fce"
+checksum = "d54ee1d4ed486f78874278e63e4069fc1ab9f6a18ca492076ffb90c5eb2997fd"
 dependencies = [
  "cfg-if",
  "serde",
@@ -353,9 +477,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.78"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a317bf8f9fba2476b4b2c85ef4c4af8ff39c3c7f0cdfeed4f82c34a880aa837b"
+checksum = "3b33f6a0694ccfea53d94db8b2ed1c3a8a4c86dd936b13b9f0a15ec4a451b900"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -368,9 +492,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.78"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d56146e7c495528bf6587663bea13a8eb588d39b36b679d83972e1a2dbbdacf9"
+checksum = "088169ca61430fe1e58b8096c24975251700e7b1f6fd91cc9d59b04fb9b18bd4"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -378,9 +502,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.78"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7803e0eea25835f8abdc585cd3021b3deb11543c6fe226dcd30b228857c5c5ab"
+checksum = "be2241542ff3d9f241f5e2cb6dd09b37efe786df8851c54957683a49f0987a97"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -391,49 +515,57 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.78"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0237232789cf037d5480773fe568aac745bfe2afbc11a863e97901780a6b47cc"
+checksum = "d7cff876b8f18eed75a66cf49b65e7f967cb354a7aa16003fb55dbfd25b44b4f"
 
 [[package]]
-name = "windows"
-version = "0.29.0"
+name = "web-sys"
+version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aac7fef12f4b59cd0a29339406cc9203ab44e440ddff6b3f5a41455349fa9cf3"
+checksum = "e828417b379f3df7111d3a2a9e5753706cae29c41f7c4029ee9fd77f3e09e582"
 dependencies = [
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_msvc",
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
-name = "windows_aarch64_msvc"
-version = "0.29.0"
+name = "webpki"
+version = "0.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d027175d00b01e0cbeb97d6ab6ebe03b12330a35786cbaca5252b1c4bf5d9b"
+checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.29.0"
+name = "webpki-roots"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8793f59f7b8e8b01eda1a652b2697d87b93097198ae85f823b969ca5b89bba58"
+checksum = "aabe153544e473b775453675851ecc86863d2a81d786d741f6b76778f2a48940"
+dependencies = [
+ "webpki",
+]
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.29.0"
+name = "winapi"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8602f6c418b67024be2996c512f5f995de3ba417f4c75af68401ab8756796ae4"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
 
 [[package]]
-name = "windows_x86_64_gnu"
-version = "0.29.0"
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3d615f419543e0bd7d2b3323af0d86ff19cbc4f816e6453f36a2c2ce889c354"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
-name = "windows_x86_64_msvc"
-version = "0.29.0"
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11d95421d9ed3672c280884da53201a5c46b7b2765ca6faf34b0d71cf34a3561"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/package.json
+++ b/package.json
@@ -50,6 +50,11 @@
     "README.md",
     "src"
   ],
+  "binary": {
+    "napi_versions": [
+      4
+    ]
+  },
   "engines": {
     "node": "^12.18.3 || >=14"
   },
@@ -59,12 +64,11 @@
     "@babel/preset-env": "^7.14.2",
     "@babel/preset-flow": "^7.13.13",
     "@babel/register": "^7.13.16",
-    "@napi-rs/cli": "^2.2.1",
+    "@napi-rs/cli": "^1.0.4",
     "cross-env": "^7.0.3",
     "flow-bin": "^0.151.0",
     "flow-copy-source": "^2.0.9",
     "fs-extra": "^10.0.0",
-    "globby": "^11.0.3",
     "husky": "6.0.0",
     "lint-staged": "^11.0.0",
     "mocha": "^8.4.0",
@@ -72,6 +76,10 @@
     "shx": "^0.3.3",
     "source-map": "^0.7.3",
     "tiny-benchy": "^2.1.0"
+  },
+  "dependencies": {
+    "detect-libc": "^1.0.3",
+    "globby": "^11.0.3"
   },
   "browser": {
     "./dist/node.js": "./dist/wasm.js",

--- a/parcel_sourcemap/Cargo.toml
+++ b/parcel_sourcemap/Cargo.toml
@@ -1,35 +1,16 @@
 [package]
-authors = ["Jasper De Moor <jasperdemoor@gmail.com>"]
-description = "Parcel Source Map Library"
-edition = "2021"
-keywords = ["sourcemap", "Node", "Parcel"]
-license = "MIT"
 name = "parcel_sourcemap"
+version = "2.0.1"
+authors = [ "Jasper De Moor <jasperdemoor@gmail.com>" ]
+edition = "2018"
+description = "Parcel Source Map Library"
+license = "MIT"
+keywords = [ "sourcemap", "Node", "Parcel" ]
 repository = "https://github.com/parcel-bundler/source-map"
-version = "2.0.0"
-
-[features]
-native = ["napi"]
-skip_napi = ["napi-derive/noop"]
-wasm = ["js-sys", "wasm-bindgen", "napi-derive/noop"]
 
 [dependencies]
+"vlq" = "0.5.1"
+"napi" = "1.6.1"
 rkyv = "0.6.7"
-vlq = "0.5.1"
-
-[dependencies.napi]
-default-features = false
-optional = true
-version = "2"
-
-[dependencies.napi-derive]
-default-features = false
-version = "2"
-
-[dependencies.js-sys]
-optional = true
-version = "0.3"
-
-[dependencies.wasm-bindgen]
-optional = true
-version = "0.2"
+"js-sys" = "0.3"
+"wasm-bindgen" = "0.2"

--- a/parcel_sourcemap/src/lib.rs
+++ b/parcel_sourcemap/src/lib.rs
@@ -667,19 +667,19 @@ impl SourceMap {
     }
 }
 
-#[allow(non_fmt_panics)]
+#[allow(non_fmt_panic)]
 #[test]
 fn test_buffers() {
     let map = SourceMap::new("/");
     let mut output = AlignedVec::new();
     match map.to_buffer(&mut output) {
         Ok(_) => {}
-        Err(err) => panic!("{:?}", err),
+        Err(err) => panic!(err),
     }
     match SourceMap::from_buffer("/", &output) {
         Ok(map) => {
             println!("{:?}", map)
         }
-        Err(err) => panic!("{:?}", err),
+        Err(err) => panic!(err),
     }
 }

--- a/parcel_sourcemap/src/mapping.rs
+++ b/parcel_sourcemap/src/mapping.rs
@@ -1,7 +1,5 @@
-use napi_derive::napi;
 use rkyv::{Archive, Deserialize, Serialize};
 
-#[napi(object)]
 #[derive(Archive, Serialize, Deserialize, Debug, Clone, Copy)]
 pub struct OriginalLocation {
     pub original_line: u32,
@@ -21,7 +19,6 @@ impl OriginalLocation {
     }
 }
 
-#[napi(object)]
 #[derive(Archive, Serialize, Deserialize, Debug)]
 pub struct Mapping {
     pub generated_line: u32,

--- a/parcel_sourcemap/src/sourcemap_error.rs
+++ b/parcel_sourcemap/src/sourcemap_error.rs
@@ -39,7 +39,6 @@ pub enum SourceMapErrorType {
     FromUtf8Error = 11,
 }
 
-#[derive(Debug)]
 pub struct SourceMapError {
     pub error_type: SourceMapErrorType,
     pub reason: Option<String>,
@@ -81,7 +80,6 @@ impl From<io::Error> for SourceMapError {
     }
 }
 
-#[cfg(feature = "native")]
 impl From<SourceMapError> for napi::Error {
     #[inline]
     fn from(err: SourceMapError) -> napi::Error {
@@ -137,7 +135,6 @@ impl From<SourceMapError> for napi::Error {
     }
 }
 
-#[cfg(feature = "wasm")]
 impl From<SourceMapError> for wasm_bindgen::JsValue {
     #[inline]
     fn from(err: SourceMapError) -> wasm_bindgen::JsValue {

--- a/parcel_sourcemap_node/Cargo.toml
+++ b/parcel_sourcemap_node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 authors = ["Jasper De Moor <jasperdemoor@gmail.com>"]
-edition = "2021"
+edition = "2018"
 name = "parcel_sourcemap_node"
 version = "2.0.1"
 
@@ -8,15 +8,15 @@ version = "2.0.1"
 crate-type = ["cdylib"]
 
 [dependencies]
-napi = {version = "2", default-features = false, features = ["napi4", "serde-json", "latin1"]}
-napi-derive = {version = "2", default-features = false}
-parcel_sourcemap = {path = "../parcel_sourcemap", features = ["native"]}
-rkyv = "0.6.7"
+napi = {version = "1.7.3", features = ["napi4", "serde-json"]}
+napi-derive = "1.1.0"
+parcel_sourcemap = {path = "../parcel_sourcemap"}
 serde = "1"
 serde_json = "1"
+rkyv = "0.6.7"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 jemallocator = {version = "0.3.2", features = ["disable_initial_exec_tls"]}
 
 [build-dependencies]
-napi-build = "1"
+napi-build = "1.0.2"

--- a/parcel_sourcemap_node/build.js
+++ b/parcel_sourcemap_node/build.js
@@ -12,16 +12,7 @@ async function build() {
   }
 
   await new Promise((resolve, reject) => {
-    let args = [
-      'build',
-      '--platform',
-      '--cargo-name',
-      'parcel_sourcemap_node',
-      '--cargo-flags="-p parcel_sourcemap_node"',
-      '--js',
-      'false',
-      './parcel_sourcemap_node/artifacts',
-    ];
+    let args = ['build', '--platform', '-c', '../package.json', './artifacts'];
     if (release) {
       args.push('--release');
     }
@@ -32,7 +23,7 @@ async function build() {
 
     let yarn = spawn('napi', args, {
       stdio: 'inherit',
-      cwd: process.cwd(),
+      cwd: __dirname,
       shell: true,
     });
 

--- a/parcel_sourcemap_node/index.js
+++ b/parcel_sourcemap_node/index.js
@@ -1,11 +1,10 @@
 let parts = [process.platform, process.arch];
-// Only GNU system has this field
-const { glibcVersionRuntime } = process.report.getReport().header;
 if (process.platform === 'linux') {
-  if (process.arch === 'arm') {
-    parts.push('gnueabihf');
-  } else if (!glibcVersionRuntime) {
+  const { MUSL, family } = require('detect-libc');
+  if (family === MUSL) {
     parts.push('musl');
+  } else if (process.arch === 'arm') {
+    parts.push('gnueabihf');
   } else {
     parts.push('gnu');
   }

--- a/parcel_sourcemap_node/src/lib.rs
+++ b/parcel_sourcemap_node/src/lib.rs
@@ -1,9 +1,13 @@
+extern crate napi;
 #[macro_use]
 extern crate napi_derive;
 extern crate parcel_sourcemap;
 extern crate rkyv;
 
-use napi::{bindgen_prelude::*, Env, JsString};
+use napi::{
+    CallContext, Either, Env, JsBuffer, JsNull, JsNumber, JsObject, JsString, JsTypedArray,
+    JsUndefined, Property, Result,
+};
 use parcel_sourcemap::{Mapping, OriginalLocation, SourceMap};
 use rkyv::AlignedVec;
 use serde_json::{from_str, to_string};
@@ -12,327 +16,509 @@ use serde_json::{from_str, to_string};
 #[global_allocator]
 static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
 
-#[napi(js_name = "SourceMap")]
-pub struct JsSourceMap(SourceMap);
+#[js_function(1)]
+fn add_source(ctx: CallContext) -> Result<JsNumber> {
+    let this: JsObject = ctx.this_unchecked();
+    let source_map_instance: &mut SourceMap = ctx.env.unwrap(&this)?;
 
-#[napi(object)]
-pub struct Position {
-    pub line: u32,
-    pub column: u32,
+    let source = ctx.get::<JsString>(0)?.into_utf8()?;
+    let source_index = source_map_instance.add_source(source.as_str()?);
+
+    ctx.env.create_uint32(source_index)
 }
 
-#[napi(object)]
-pub struct MappingObject {
-    pub original: Option<Position>,
-    pub generated: Position,
-    pub source: Option<u32>,
-    pub name: Option<u32>,
+#[js_function(1)]
+fn get_source(ctx: CallContext) -> Result<JsString> {
+    let this: JsObject = ctx.this_unchecked();
+    let source_map_instance: &SourceMap = ctx.env.unwrap(&this)?;
+
+    let source_index = ctx.get::<JsNumber>(0)?.get_uint32()?;
+    match source_map_instance.get_source(source_index) {
+        Ok(source) => ctx.env.create_string(source),
+        Err(_err) => ctx.env.create_string(""),
+    }
 }
 
-#[napi(object)]
-pub struct VlqMapping {
-    pub mappings: JsString,
-    pub sources: Array,
-    pub sources_content: Array,
-    pub names: Array,
+fn _get_sources(ctx: &CallContext) -> Result<JsObject> {
+    let this: JsObject = ctx.this_unchecked();
+    let source_map_instance: &SourceMap = ctx.env.unwrap(&this)?;
+
+    let mut napi_sources_array = ctx
+        .env
+        .create_array_with_length(source_map_instance.get_sources().len())?;
+    for (source_index, source) in source_map_instance.get_sources().iter().enumerate() {
+        napi_sources_array
+            .set_element(source_index as u32, ctx.env.create_string(source.as_str())?)?;
+    }
+
+    // Return array
+    Ok(napi_sources_array)
 }
 
-#[napi]
-impl JsSourceMap {
-    #[napi(constructor)]
-    pub fn new(project_root: String, second_argument: Option<Buffer>) -> Result<Self> {
-        match second_argument {
-            Some(js_buffer) => Ok(Self(SourceMap::from_buffer(
-                project_root.as_str(),
-                js_buffer.as_ref(),
-            )?)),
-            None => Ok(Self(SourceMap::new(project_root.as_str()))),
-        }
-    }
+#[js_function]
+fn get_sources(ctx: CallContext) -> Result<JsString> {
+    let this: JsObject = ctx.this_unchecked();
+    let source_map_instance: &SourceMap = ctx.env.unwrap(&this)?;
+    let sources_str = to_string(&source_map_instance.get_sources())?;
+    return ctx.env.create_string(sources_str.as_str());
+}
 
-    #[napi]
-    pub fn add_source(&mut self, source: String) -> u32 {
-        self.0.add_source(source.as_str())
-    }
+fn _get_sources_content(ctx: &CallContext) -> Result<JsObject> {
+    let this: JsObject = ctx.this_unchecked();
+    let source_map_instance: &SourceMap = ctx.env.unwrap(&this)?;
 
-    #[napi]
-    pub fn get_source(&self, source_index: u32) -> String {
-        match self.0.get_source(source_index) {
-            Ok(source) => source,
-            Err(_err) => "",
-        }
-        .to_owned()
-    }
-
-    #[napi]
-    pub fn _get_sources(&self) -> &Vec<String> {
-        self.0.get_sources()
-    }
-
-    #[napi]
-    pub fn get_sources(&self) -> Result<String> {
-        Ok(to_string(self.0.get_sources())?)
-    }
-
-    #[napi]
-    pub fn get_sources_content(&self) -> &Vec<String> {
-        self.0.get_sources_content()
-    }
-
-    #[napi]
-    pub fn get_source_index(&self, source: String) -> Result<i32> {
-        Ok(self
-            .0
-            .get_source_index(source.as_str())?
-            .map(|i| i as i32)
-            .unwrap_or(-1))
-    }
-
-    #[napi]
-    pub fn set_source_content_by_source(
-        &mut self,
-        source: String,
-        source_content: String,
-    ) -> Result<()> {
-        let source_index: usize = self.0.add_source(source.as_str()) as usize;
-        self.0
-            .set_source_content(source_index, source_content.as_str())?;
-        Ok(())
-    }
-
-    #[napi]
-    pub fn get_source_content_by_source(&self, source: String) -> Result<String> {
-        let source_index = self.0.get_source_index(source.as_str())?;
-        Ok(match source_index {
-            Some(i) => self.0.get_source_content(i)?,
-            None => "",
-        }
-        .to_owned())
-    }
-
-    #[napi]
-    pub fn add_name(&mut self, name: String) -> u32 {
-        self.0.add_name(name.as_str())
-    }
-
-    #[napi]
-    pub fn get_name(&self, name_index: u32) -> String {
-        match self.0.get_name(name_index) {
-            Ok(name) => name,
-            Err(_err) => "",
-        }
-        .to_owned()
-    }
-
-    #[napi]
-    pub fn get_names(&self) -> Result<String> {
-        Ok(to_string(&self.0.get_names())?)
-    }
-
-    #[napi]
-    pub fn get_name_index(&self, name: String) -> Result<i32> {
-        Ok(self
-            .0
-            .get_name_index(name.as_str())
-            .map(|i| i as i32)
-            .unwrap_or(-1))
-    }
-
-    #[napi(
-        ts_args_type = "mapping: { generatedLine: number; generatedColumn: number; original?: { originalLine: number; originalColumn: number; source: number; name?: number; } }"
-    )]
-    pub fn mapping_to_js_object(&self, mapping: Mapping) -> MappingObject {
-        let generated_position_obj = Position {
-            line: mapping.generated_line + 1,
-            column: mapping.generated_column,
-        };
-
-        let original_position = mapping.original;
-        MappingObject {
-            generated: generated_position_obj,
-            original: original_position.map(|original_position| Position {
-                line: original_position.original_line + 1,
-                column: original_position.original_column,
-            }),
-            source: original_position.map(|o| o.source),
-            name: original_position.and_then(|o| o.name),
-        }
-    }
-
-    #[napi]
-    pub fn get_mappings(&self) -> Vec<MappingObject> {
-        self.0
-            .get_mappings()
-            .iter()
-            .map(|mapping| MappingObject {
-                generated: Position {
-                    line: mapping.generated_line + 1,
-                    column: mapping.generated_column,
-                },
-                original: mapping.original.map(|original_position| Position {
-                    line: original_position.original_line + 1,
-                    column: original_position.original_column,
-                }),
-                source: mapping.original.map(|o| o.source),
-                name: mapping.original.and_then(|o| o.name),
-            })
-            .collect()
-    }
-
-    #[napi]
-    pub fn to_buffer(&self) -> Result<Buffer> {
-        let mut buffer_data = AlignedVec::new();
-        self.0.to_buffer(&mut buffer_data)?;
-        Ok(buffer_data.into_vec().into())
-    }
-
-    #[napi]
-    pub fn add_source_map(
-        &mut self,
-        previous_map_instance: &mut JsSourceMap,
-        line_offset: i64,
-    ) -> Result<()> {
-        self.0
-            .add_sourcemap(&mut previous_map_instance.0, line_offset)?;
-        Ok(())
-    }
-
-    #[napi(js_name = "addVLQMap")]
-    pub fn add_vlq_map(
-        &mut self,
-        vlq_mappings: String,
-        js_sources_arr_input: String,
-        js_sources_content_arr_input: String,
-        js_names_arr_input: String,
-        line_offset: i64,
-        column_offset: i64,
-    ) -> Result<()> {
-        let sources: Vec<String> = from_str(js_sources_arr_input.as_str())?;
-        let sources_content: Vec<String> = from_str(js_sources_content_arr_input.as_str())?;
-        let names: Vec<String> = from_str(js_names_arr_input.as_str())?;
-
-        self.0.add_vlq_map(
-            vlq_mappings.as_bytes(),
-            sources.iter().map(|s| s.as_str()).collect(),
-            sources_content.iter().map(|s| s.as_str()).collect(),
-            names.iter().map(|s| s.as_str()).collect(),
-            line_offset,
-            column_offset,
+    let mut napi_sources_content_array = ctx
+        .env
+        .create_array_with_length(source_map_instance.get_sources_content().len())?;
+    for (source_index, source_content) in
+        source_map_instance.get_sources_content().iter().enumerate()
+    {
+        napi_sources_content_array.set_element(
+            source_index as u32,
+            ctx.env.create_string(source_content.as_str())?,
         )?;
-        Ok(())
     }
 
-    #[napi(js_name = "toVLQ")]
-    pub fn to_vlq(&mut self, env: Env) -> Result<VlqMapping> {
-        let mut vlq_output: Vec<u8> = vec![];
-        self.0.write_vlq(&mut vlq_output)?;
-        let vlq_string = env.create_string_latin1(vlq_output.as_slice())?;
-        Ok(VlqMapping {
-            sources: Array::from_ref_vec_string(&env, self.0.get_sources())?,
-            mappings: vlq_string,
-            sources_content: Array::from_ref_vec_string(&env, self.get_sources_content())?,
-            names: Array::from_ref_vec_string(&env, self.0.get_names())?,
-        })
+    // Return array
+    Ok(napi_sources_content_array)
+}
+
+#[js_function]
+fn get_sources_content(ctx: CallContext) -> Result<JsObject> {
+    _get_sources_content(&ctx)
+}
+
+#[js_function(1)]
+fn get_source_index(ctx: CallContext) -> Result<JsNumber> {
+    let this: JsObject = ctx.this_unchecked();
+    let source_map_instance: &SourceMap = ctx.env.unwrap(&this)?;
+
+    let source = ctx.get::<JsString>(0)?.into_utf8()?;
+    let source_index = source_map_instance.get_source_index(source.as_str()?)?;
+    match source_index {
+        Some(i) => ctx.env.create_uint32(i),
+        None => ctx.env.create_int32(-1),
+    }
+}
+
+#[js_function(2)]
+fn set_source_content_by_source(ctx: CallContext) -> Result<JsUndefined> {
+    let this: JsObject = ctx.this_unchecked();
+    let source_map_instance: &mut SourceMap = ctx.env.unwrap(&this)?;
+
+    let source = ctx.get::<JsString>(0)?.into_utf8()?;
+    let source_index: usize = source_map_instance.add_source(source.as_str()?) as usize;
+    let source_content = ctx.get::<JsString>(1)?.into_utf8()?;
+    source_map_instance.set_source_content(source_index, source_content.as_str()?)?;
+
+    ctx.env.get_undefined()
+}
+
+#[js_function(1)]
+fn get_source_content_by_source(ctx: CallContext) -> Result<JsString> {
+    let this: JsObject = ctx.this_unchecked();
+    let source_map_instance: &mut SourceMap = ctx.env.unwrap(&this)?;
+
+    let source = ctx.get::<JsString>(0)?.into_utf8()?;
+    let source_index = source_map_instance.get_source_index(source.as_str()?)?;
+    match source_index {
+        Some(i) => {
+            let source_content = source_map_instance.get_source_content(i)?;
+            ctx.env.create_string(source_content)
+        }
+        None => ctx.env.create_string(""),
+    }
+}
+
+#[js_function(1)]
+fn add_name(ctx: CallContext) -> Result<JsNumber> {
+    let this: JsObject = ctx.this_unchecked();
+    let source_map_instance: &mut SourceMap = ctx.env.unwrap(&this)?;
+
+    let name = ctx.get::<JsString>(0)?.into_utf8()?;
+    let name_index = source_map_instance.add_name(name.as_str()?);
+    ctx.env.create_uint32(name_index)
+}
+
+#[js_function(1)]
+fn get_name(ctx: CallContext) -> Result<JsString> {
+    let this: JsObject = ctx.this_unchecked();
+    let source_map_instance: &SourceMap = ctx.env.unwrap(&this)?;
+
+    let name_index = ctx.get::<JsNumber>(0)?.get_uint32()?;
+    match source_map_instance.get_name(name_index) {
+        Ok(name) => ctx.env.create_string(name),
+        Err(_err) => ctx.env.create_string(""),
+    }
+}
+
+fn _get_names(ctx: &CallContext) -> Result<JsObject> {
+    let this: JsObject = ctx.this_unchecked();
+    let source_map_instance: &SourceMap = ctx.env.unwrap(&this)?;
+
+    let mut napi_names_array = ctx
+        .env
+        .create_array_with_length(source_map_instance.get_names().len())?;
+    for (name_index, name) in source_map_instance.get_names().iter().enumerate() {
+        napi_names_array.set_element(name_index as u32, ctx.env.create_string(name.as_str())?)?;
     }
 
-    #[napi]
-    pub fn add_indexed_mappings(&mut self, mappings_arr: Int32Array) {
-        let mappings_count = mappings_arr.len();
+    // Return array
+    Ok(napi_names_array)
+}
 
-        let mut generated_line: u32 = 0; // 0
-        let mut generated_column: u32 = 0; // 1
-        let mut original_line: i32 = 0; // 2
-        let mut original_column: i32 = 0; // 3
-        let mut original_source: i32 = 0; // 4
-        for (i, value) in mappings_arr.iter().enumerate().take(mappings_count) {
-            let value = *value;
-            match i % 6 {
-                0 => {
-                    generated_line = value as u32;
-                }
-                1 => {
-                    generated_column = value as u32;
-                }
-                2 => {
-                    original_line = value;
-                }
-                3 => {
-                    original_column = value;
-                }
-                4 => {
-                    original_source = value;
-                }
-                5 => {
-                    self.0.add_mapping(
-                        generated_line,
-                        generated_column,
-                        if original_line > -1 && original_column > -1 && original_source > -1 {
-                            Some(OriginalLocation {
-                                original_line: original_line as u32,
-                                original_column: original_column as u32,
-                                source: original_source as u32,
-                                name: if value > -1 { Some(value as u32) } else { None },
-                            })
-                        } else {
-                            None
-                        },
-                    );
-                }
-                _ => unreachable!(),
-            }
+#[js_function]
+fn get_names(ctx: CallContext) -> Result<JsString> {
+    let this: JsObject = ctx.this_unchecked();
+    let source_map_instance: &SourceMap = ctx.env.unwrap(&this)?;
+    let names_str = to_string(&source_map_instance.get_names())?;
+    return ctx.env.create_string(names_str.as_str());
+}
+
+#[js_function(1)]
+fn get_name_index(ctx: CallContext) -> Result<JsNumber> {
+    let this: JsObject = ctx.this_unchecked();
+    let source_map_instance: &SourceMap = ctx.env.unwrap(&this)?;
+
+    let name = ctx.get::<JsString>(0)?.into_utf8()?;
+    let name_index = source_map_instance.get_name_index(name.as_str()?);
+
+    match name_index {
+        Some(i) => ctx.env.create_uint32(i),
+        None => ctx.env.create_int32(-1),
+    }
+}
+
+fn mapping_to_js_object(ctx: &CallContext, mapping: &Mapping) -> Result<JsObject> {
+    let mut mapping_obj = ctx.env.create_object()?;
+
+    let mut generated_position_obj = ctx.env.create_object()?;
+    generated_position_obj
+        .set_named_property("line", ctx.env.create_uint32((mapping.generated_line) + 1)?)?;
+    generated_position_obj
+        .set_named_property("column", ctx.env.create_uint32(mapping.generated_column)?)?;
+    mapping_obj.set_named_property("generated", generated_position_obj)?;
+
+    let original_position = mapping.original;
+    if let Some(original_position) = original_position {
+        let mut original_position_obj = ctx.env.create_object()?;
+        original_position_obj.set_named_property(
+            "line",
+            ctx.env.create_uint32(original_position.original_line + 1)?,
+        )?;
+        original_position_obj.set_named_property(
+            "column",
+            ctx.env.create_uint32(original_position.original_column)?,
+        )?;
+        mapping_obj.set_named_property("original", original_position_obj)?;
+
+        mapping_obj
+            .set_named_property("source", ctx.env.create_uint32(original_position.source)?)?;
+
+        if let Some(name) = original_position.name {
+            mapping_obj.set_named_property("name", ctx.env.create_uint32(name)?)?;
         }
     }
 
-    #[napi]
-    pub fn offset_lines(&mut self, generated_line: u32, generated_line_offset: i64) -> Result<()> {
-        self.0.offset_lines(generated_line, generated_line_offset)?;
-        Ok(())
+    Ok(mapping_obj)
+}
+
+#[js_function]
+fn get_mappings(ctx: CallContext) -> Result<JsObject> {
+    let this: JsObject = ctx.this_unchecked();
+    let source_map_instance: &SourceMap = ctx.env.unwrap(&this)?;
+
+    let mut mappings_arr = ctx.env.create_array()?;
+    for (index, mapping) in source_map_instance.get_mappings().iter().enumerate() {
+        mappings_arr.set_element(index as u32, mapping_to_js_object(&ctx, &mapping)?)?;
+    }
+    Ok(mappings_arr)
+}
+
+#[js_function]
+fn to_buffer(ctx: CallContext) -> Result<JsBuffer> {
+    let this: JsObject = ctx.this_unchecked();
+    let source_map_instance: &SourceMap = ctx.env.unwrap(&this)?;
+
+    let mut buffer_data = AlignedVec::new();
+    source_map_instance.to_buffer(&mut buffer_data)?;
+    Ok(ctx
+        .env
+        .create_buffer_with_data(buffer_data.into_vec())?
+        .into_raw())
+}
+
+#[js_function(2)]
+fn add_sourcemap(ctx: CallContext) -> Result<JsUndefined> {
+    let this: JsObject = ctx.this_unchecked();
+    let source_map_instance: &mut SourceMap = ctx.env.unwrap(&this)?;
+
+    let sourcemap_object = ctx.get::<JsObject>(0)?;
+    let previous_map_instance = ctx.env.unwrap::<SourceMap>(&sourcemap_object)?;
+    let line_offset = ctx.get::<JsNumber>(1)?.get_int64()?;
+
+    source_map_instance.add_sourcemap(previous_map_instance, line_offset)?;
+    ctx.env.get_undefined()
+}
+
+#[js_function(6)]
+fn add_vlq_map(ctx: CallContext) -> Result<JsUndefined> {
+    let this: JsObject = ctx.this_unchecked();
+    let source_map_instance: &mut SourceMap = ctx.env.unwrap(&this)?;
+
+    let vlq_mappings = ctx.get::<JsString>(0)?.into_utf8()?;
+
+    let js_sources_arr_input = ctx.get::<JsString>(1)?.into_utf8()?;
+    let sources: Vec<String> = from_str(js_sources_arr_input.as_str()?)?;
+
+    let js_sources_content_arr_input = ctx.get::<JsString>(2)?.into_utf8()?;
+    let sources_content: Vec<String> = from_str(js_sources_content_arr_input.as_str()?)?;
+
+    let js_names_arr_input = ctx.get::<JsString>(3)?.into_utf8()?;
+    let names: Vec<String> = from_str(js_names_arr_input.as_str()?)?;
+
+    let line_offset = ctx.get::<JsNumber>(4)?.get_int64()?;
+    let column_offset = ctx.get::<JsNumber>(5)?.get_int64()?;
+
+    source_map_instance.add_vlq_map(
+        vlq_mappings.as_slice(),
+        sources.iter().map(|s| s.as_str()).collect(),
+        sources_content.iter().map(|s| s.as_str()).collect(),
+        names.iter().map(|s| s.as_str()).collect(),
+        line_offset,
+        column_offset,
+    )?;
+
+    ctx.env.get_undefined()
+}
+
+#[js_function]
+fn to_vlq(ctx: CallContext) -> Result<JsObject> {
+    let this: JsObject = ctx.this_unchecked();
+    let source_map_instance: &mut SourceMap = ctx.env.unwrap(&this)?;
+
+    let mut vlq_output: Vec<u8> = vec![];
+    source_map_instance.write_vlq(&mut vlq_output)?;
+    let vlq_string = ctx.env.create_string_latin1(vlq_output.as_slice())?;
+    let mut result_obj: JsObject = ctx.env.create_object()?;
+    result_obj.set_named_property("mappings", vlq_string)?;
+    result_obj.set_named_property("sources", _get_sources(&ctx)?)?;
+    result_obj.set_named_property("sourcesContent", _get_sources_content(&ctx)?)?;
+    result_obj.set_named_property("names", _get_names(&ctx)?)?;
+
+    Ok(result_obj)
+}
+
+#[js_function(1)]
+fn add_indexed_mappings(ctx: CallContext) -> Result<JsUndefined> {
+    let this: JsObject = ctx.this_unchecked();
+    let source_map_instance: &mut SourceMap = ctx.env.unwrap(&this)?;
+
+    let mappings = ctx.get::<JsTypedArray>(0)?;
+    let mappings_value = mappings.into_value()?;
+    let mappings_arr: &[i32] = mappings_value.as_ref();
+    let mappings_count = mappings_arr.len();
+
+    let mut generated_line: u32 = 0; // 0
+    let mut generated_column: u32 = 0; // 1
+    let mut original_line: i32 = 0; // 2
+    let mut original_column: i32 = 0; // 3
+    let mut original_source: i32 = 0; // 4
+    for (i, value) in mappings_arr.iter().enumerate().take(mappings_count) {
+        let value = *value;
+        match i % 6 {
+            0 => {
+                generated_line = value as u32;
+            }
+            1 => {
+                generated_column = value as u32;
+            }
+            2 => {
+                original_line = value;
+            }
+            3 => {
+                original_column = value;
+            }
+            4 => {
+                original_source = value;
+            }
+            5 => {
+                source_map_instance.add_mapping(
+                    generated_line,
+                    generated_column,
+                    if original_line > -1 && original_column > -1 && original_source > -1 {
+                        Some(OriginalLocation {
+                            original_line: original_line as u32,
+                            original_column: original_column as u32,
+                            source: original_source as u32,
+                            name: if value > -1 { Some(value as u32) } else { None },
+                        })
+                    } else {
+                        None
+                    },
+                );
+            }
+            _ => unreachable!(),
+        }
     }
 
-    #[napi]
-    pub fn offset_columns(
-        &mut self,
-        generated_line: u32,
-        generated_column: u32,
-        generated_column_offset: i64,
-    ) -> Result<()> {
-        self.0
-            .offset_columns(generated_line, generated_column, generated_column_offset)?;
-        Ok(())
-    }
+    ctx.env.get_undefined()
+}
 
-    #[napi]
-    pub fn add_empty_map(
-        &mut self,
-        source: String,
-        source_content: String,
-        line_offset: i64,
-    ) -> Result<()> {
-        self.0
-            .add_empty_map(source.as_str(), source_content.as_str(), line_offset)?;
-        Ok(())
-    }
+#[js_function(2)]
+fn offset_lines(ctx: CallContext) -> Result<JsUndefined> {
+    let this: JsObject = ctx.this_unchecked();
+    let source_map_instance: &mut SourceMap = ctx.env.unwrap(&this)?;
 
-    #[napi]
-    pub fn extends(&mut self, previous_map_instance: &mut JsSourceMap) -> Result<()> {
-        self.0.extends(&mut previous_map_instance.0)?;
-        Ok(())
-    }
+    let generated_line = ctx.get::<JsNumber>(0)?.get_uint32()?;
+    let generated_line_offset = ctx.get::<JsNumber>(1)?.get_int64()?;
+    source_map_instance.offset_lines(generated_line, generated_line_offset)?;
+    ctx.env.get_undefined()
+}
 
-    #[napi]
-    pub fn find_closest_mapping(
-        &mut self,
-        generated_line: u32,
-        generated_column: u32,
-    ) -> Result<Option<MappingObject>> {
-        Ok(self
-            .0
-            .find_closest_mapping(generated_line, generated_column)
-            .map(|mapping| self.mapping_to_js_object(mapping)))
-    }
+#[js_function(3)]
+fn offset_columns(ctx: CallContext) -> Result<JsUndefined> {
+    let this: JsObject = ctx.this_unchecked();
+    let source_map_instance: &mut SourceMap = ctx.env.unwrap(&this)?;
 
-    #[napi]
-    pub fn get_project_root(&self) -> &str {
-        self.0.project_root.as_str()
+    let generated_line = ctx.get::<JsNumber>(0)?.get_uint32()?;
+    let generated_column = ctx.get::<JsNumber>(1)?.get_uint32()?;
+    let generated_column_offset = ctx.get::<JsNumber>(2)?.get_int64()?;
+
+    source_map_instance.offset_columns(
+        generated_line,
+        generated_column,
+        generated_column_offset,
+    )?;
+    ctx.env.get_undefined()
+}
+
+#[js_function(3)]
+fn add_empty_map(ctx: CallContext) -> Result<JsUndefined> {
+    let this: JsObject = ctx.this_unchecked();
+    let source_map_instance: &mut SourceMap = ctx.env.unwrap(&this)?;
+
+    let source = ctx.get::<JsString>(0)?.into_utf8()?;
+    let source_content = ctx.get::<JsString>(1)?.into_utf8()?;
+    let line_offset = ctx.get::<JsNumber>(2)?.get_int64()?;
+    source_map_instance.add_empty_map(source.as_str()?, source_content.as_str()?, line_offset)?;
+    ctx.env.get_undefined()
+}
+
+#[js_function(1)]
+fn extends(ctx: CallContext) -> Result<JsUndefined> {
+    let this: JsObject = ctx.this_unchecked();
+    let source_map_instance: &mut SourceMap = ctx.env.unwrap(&this)?;
+
+    let sourcemap_object = ctx.get::<JsObject>(0)?;
+    let mut previous_map_instance = ctx.env.unwrap::<SourceMap>(&sourcemap_object)?;
+    source_map_instance.extends(&mut previous_map_instance)?;
+    ctx.env.get_undefined()
+}
+
+#[js_function(2)]
+fn find_closest_mapping(ctx: CallContext) -> Result<Either<JsObject, JsNull>> {
+    let this: JsObject = ctx.this_unchecked();
+    let source_map_instance: &mut SourceMap = ctx.env.unwrap(&this)?;
+
+    let generated_line = ctx.get::<JsNumber>(0)?.get_uint32()?;
+    let generated_column = ctx.get::<JsNumber>(1)?.get_uint32()?;
+    match source_map_instance.find_closest_mapping(generated_line, generated_column) {
+        Some(mapping) => mapping_to_js_object(&ctx, &mapping).map(Either::A),
+        None => ctx.env.get_null().map(Either::B),
     }
+}
+
+#[js_function]
+fn get_project_root(ctx: CallContext) -> Result<JsString> {
+    let this: JsObject = ctx.this_unchecked();
+    let source_map_instance: &mut SourceMap = ctx.env.unwrap(&this)?;
+
+    return ctx
+        .env
+        .create_string(source_map_instance.project_root.as_str());
+}
+
+#[js_function(2)]
+fn constructor(ctx: CallContext) -> Result<JsUndefined> {
+    let mut this: JsObject = ctx.this_unchecked();
+    let project_root = ctx.get::<JsString>(0)?.into_utf8()?;
+    let second_argument = ctx.get::<Either<JsBuffer, JsUndefined>>(1)?;
+    match second_argument {
+        Either::A(js_buffer) => {
+            let buffer = js_buffer.into_value()?;
+            let sourcemap = SourceMap::from_buffer(project_root.as_str()?, &buffer[..])?;
+            ctx.env.wrap(&mut this, sourcemap)?;
+        }
+        Either::B(_) => {
+            ctx.env
+                .wrap(&mut this, SourceMap::new(project_root.as_str()?))?;
+        }
+    }
+    ctx.env.get_undefined()
+}
+
+#[module_exports]
+fn init(mut exports: JsObject, env: Env) -> Result<()> {
+    let add_source_method = Property::new(&env, "addSource")?.with_method(add_source);
+    let get_source_method = Property::new(&env, "getSource")?.with_method(get_source);
+    let get_sources_method = Property::new(&env, "getSources")?.with_method(get_sources);
+    let get_source_index_method =
+        Property::new(&env, "getSourceIndex")?.with_method(get_source_index);
+    let set_source_content_by_source_method =
+        Property::new(&env, "setSourceContentBySource")?.with_method(set_source_content_by_source);
+    let get_source_content_by_source_method =
+        Property::new(&env, "getSourceContentBySource")?.with_method(get_source_content_by_source);
+    let get_sources_content_method =
+        Property::new(&env, "getSourcesContent")?.with_method(get_sources_content);
+    let add_name_method = Property::new(&env, "addName")?.with_method(add_name);
+    let get_name_method = Property::new(&env, "getName")?.with_method(get_name);
+    let get_names_method = Property::new(&env, "getNames")?.with_method(get_names);
+    let get_name_index_method = Property::new(&env, "getNameIndex")?.with_method(get_name_index);
+    let get_mappings_method = Property::new(&env, "getMappings")?.with_method(get_mappings);
+    let to_buffer_method = Property::new(&env, "toBuffer")?.with_method(to_buffer);
+    let add_sourcemap_method = Property::new(&env, "addSourceMap")?.with_method(add_sourcemap);
+    let add_indexed_mappings_method =
+        Property::new(&env, "addIndexedMappings")?.with_method(add_indexed_mappings);
+    let add_vlq_map_method = Property::new(&env, "addVLQMap")?.with_method(add_vlq_map);
+    let to_vlq_method = Property::new(&env, "toVLQ")?.with_method(to_vlq);
+    let offset_lines_method = Property::new(&env, "offsetLines")?.with_method(offset_lines);
+    let offset_columns_method = Property::new(&env, "offsetColumns")?.with_method(offset_columns);
+    let add_empty_map_method = Property::new(&env, "addEmptyMap")?.with_method(add_empty_map);
+    let extends_method = Property::new(&env, "extends")?.with_method(extends);
+    let get_project_root_method =
+        Property::new(&env, "getProjectRoot")?.with_method(get_project_root);
+    let find_closest_mapping_method =
+        Property::new(&env, "findClosestMapping")?.with_method(find_closest_mapping);
+    let sourcemap_class = env.define_class(
+        "SourceMap",
+        constructor,
+        &[
+            add_source_method,
+            get_source_method,
+            get_sources_method,
+            get_source_index_method,
+            set_source_content_by_source_method,
+            get_source_content_by_source_method,
+            get_sources_content_method,
+            add_name_method,
+            get_name_method,
+            get_names_method,
+            get_name_index_method,
+            get_mappings_method,
+            add_sourcemap_method,
+            add_indexed_mappings_method,
+            add_vlq_map_method,
+            to_buffer_method,
+            to_vlq_method,
+            offset_lines_method,
+            offset_columns_method,
+            add_empty_map_method,
+            extends_method,
+            find_closest_mapping_method,
+            get_project_root_method,
+        ],
+    )?;
+    exports.set_named_property("SourceMap", sourcemap_class)?;
+    Ok(())
 }

--- a/parcel_sourcemap_wasm/Cargo.toml
+++ b/parcel_sourcemap_wasm/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
-authors = ["Jasper De Moor <jasperdemoor@gmail.com>"]
-edition = "2021"
 name = "parcel_sourcemap_wasm"
 version = "2.0.1"
+authors = ["Jasper De Moor <jasperdemoor@gmail.com>"]
+edition = "2018"
 
 [lib]
 crate-type = ["cdylib"]
 
 [dependencies]
+parcel_sourcemap = { path = "../parcel_sourcemap" }
+serde = { version = "1.0", features = ["derive"] }
+wasm-bindgen = { version = "0.2", features = ["serde-serialize"] }
 js-sys = "0.3"
-parcel_sourcemap = {path = "../parcel_sourcemap", features = ["skip_napi", "wasm"]}
 rkyv = "0.6.7"
-serde = {version = "1.0", features = ["derive"]}
-wasm-bindgen = {version = "0.2", features = ["serde-serialize"]}

--- a/yarn.lock
+++ b/yarn.lock
@@ -919,10 +919,21 @@
     "@babel/helper-validator-identifier" "^7.14.5"
     to-fast-properties "^2.0.0"
 
-"@napi-rs/cli@^2.2.1":
-  version "2.2.1"
-  resolved "https://registry.npmjs.org/@napi-rs/cli/-/cli-2.2.1.tgz#18d91cc717c20c74a5a0383edf4eaf4fa68a5e04"
-  integrity sha512-WExRk0aHesXcUPpTC104sn7M7rKJFfjngw532tdGyNU3xYfLU64x8aJEr1RFyLoM5wBpBPHufsa3ate/BxqJtA==
+"@napi-rs/cli@^1.0.4":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@napi-rs/cli/-/cli-1.1.0.tgz#ca58a0ff18a0af133f009773282846fb4509f9d1"
+  integrity sha512-eGOOybqsuABoeocHron/R8cA4A1JJeLlt8dBsmyIbdXduEs0SPr+caLX5avdz8D4xG9tYfxj0k8fN/PAletLPA==
+  dependencies:
+    "@octokit/rest" "^18.5.6"
+    chalk "^4.1.1"
+    clipanion "^2.6.2"
+    debug "^4.3.1"
+    fdir "^5.1.0"
+    inquirer "^8.1.0"
+    lodash "^4.17.21"
+    putasset "^5.0.3"
+    toml "^3.0.0"
+    tslib "^2.2.0"
 
 "@nicolo-ribaudo/chokidar-2@2.1.8-no-fsevents.2":
   version "2.1.8-no-fsevents.2"
@@ -962,6 +973,156 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
+"@octokit/auth-token@^2.4.0", "@octokit/auth-token@^2.4.4":
+  version "2.4.5"
+  resolved "https://registry.yarnpkg.com/@octokit/auth-token/-/auth-token-2.4.5.tgz#568ccfb8cb46f36441fac094ce34f7a875b197f3"
+  integrity sha512-BpGYsPgJt05M7/L/5FoE1PiAbdxXFZkX/3kDYcsvd1v6UhlnE5e96dTDr0ezX/EFwciQxf3cNV0loipsURU+WA==
+  dependencies:
+    "@octokit/types" "^6.0.3"
+
+"@octokit/core@^2.4.3":
+  version "2.5.4"
+  resolved "https://registry.yarnpkg.com/@octokit/core/-/core-2.5.4.tgz#f7fbf8e4f86c5cc2497a8887ba2561ec8d358054"
+  integrity sha512-HCp8yKQfTITYK+Nd09MHzAlP1v3Ii/oCohv0/TW9rhSLvzb98BOVs2QmVYuloE6a3l6LsfyGIwb6Pc4ycgWlIQ==
+  dependencies:
+    "@octokit/auth-token" "^2.4.0"
+    "@octokit/graphql" "^4.3.1"
+    "@octokit/request" "^5.4.0"
+    "@octokit/types" "^5.0.0"
+    before-after-hook "^2.1.0"
+    universal-user-agent "^5.0.0"
+
+"@octokit/core@^3.5.0":
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/@octokit/core/-/core-3.5.1.tgz#8601ceeb1ec0e1b1b8217b960a413ed8e947809b"
+  integrity sha512-omncwpLVxMP+GLpLPgeGJBF6IWJFjXDS5flY5VbppePYX9XehevbDykRH9PdCdvqt9TS5AOTiDide7h0qrkHjw==
+  dependencies:
+    "@octokit/auth-token" "^2.4.4"
+    "@octokit/graphql" "^4.5.8"
+    "@octokit/request" "^5.6.0"
+    "@octokit/request-error" "^2.0.5"
+    "@octokit/types" "^6.0.3"
+    before-after-hook "^2.2.0"
+    universal-user-agent "^6.0.0"
+
+"@octokit/endpoint@^6.0.1":
+  version "6.0.12"
+  resolved "https://registry.yarnpkg.com/@octokit/endpoint/-/endpoint-6.0.12.tgz#3b4d47a4b0e79b1027fb8d75d4221928b2d05658"
+  integrity sha512-lF3puPwkQWGfkMClXb4k/eUT/nZKQfxinRWJrdZaJO85Dqwo/G0yOC434Jr2ojwafWJMYqFGFa5ms4jJUgujdA==
+  dependencies:
+    "@octokit/types" "^6.0.3"
+    is-plain-object "^5.0.0"
+    universal-user-agent "^6.0.0"
+
+"@octokit/graphql@^4.3.1", "@octokit/graphql@^4.5.8":
+  version "4.6.4"
+  resolved "https://registry.yarnpkg.com/@octokit/graphql/-/graphql-4.6.4.tgz#0c3f5bed440822182e972317122acb65d311a5ed"
+  integrity sha512-SWTdXsVheRmlotWNjKzPOb6Js6tjSqA2a8z9+glDJng0Aqjzti8MEWOtuT8ZSu6wHnci7LZNuarE87+WJBG4vg==
+  dependencies:
+    "@octokit/request" "^5.6.0"
+    "@octokit/types" "^6.0.3"
+    universal-user-agent "^6.0.0"
+
+"@octokit/openapi-types@^8.2.1":
+  version "8.2.1"
+  resolved "https://registry.yarnpkg.com/@octokit/openapi-types/-/openapi-types-8.2.1.tgz#102e752a7378ff8d21057c70fd16f1c83856d8c5"
+  integrity sha512-BJz6kWuL3n+y+qM8Pv+UGbSxH6wxKf/SBs5yzGufMHwDefsa+Iq7ZGy1BINMD2z9SkXlIzk1qiu988rMuGXEMg==
+
+"@octokit/plugin-paginate-rest@^2.2.0", "@octokit/plugin-paginate-rest@^2.6.2":
+  version "2.14.0"
+  resolved "https://registry.yarnpkg.com/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.14.0.tgz#f469cb4a908792fb44679c5973d8bba820c88b0f"
+  integrity sha512-S2uEu2uHeI7Vf+Lvj8tv3O5/5TCAa8GHS0dUQN7gdM7vKA6ZHAbR6HkAVm5yMb1mbedLEbxOuQ+Fa0SQ7tCDLA==
+  dependencies:
+    "@octokit/types" "^6.18.0"
+
+"@octokit/plugin-request-log@^1.0.0", "@octokit/plugin-request-log@^1.0.2":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz#5e50ed7083a613816b1e4a28aeec5fb7f1462e85"
+  integrity sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==
+
+"@octokit/plugin-rest-endpoint-methods@3.17.0":
+  version "3.17.0"
+  resolved "https://registry.yarnpkg.com/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-3.17.0.tgz#d8ba04eb883849dd98666c55bf49d8c9fe7be055"
+  integrity sha512-NFV3vq7GgoO2TrkyBRUOwflkfTYkFKS0tLAPym7RNpkwLCttqShaEGjthOsPEEL+7LFcYv3mU24+F2yVd3npmg==
+  dependencies:
+    "@octokit/types" "^4.1.6"
+    deprecation "^2.3.1"
+
+"@octokit/plugin-rest-endpoint-methods@5.4.1":
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.4.1.tgz#540ec90bb753dcaa682ee9f2cd6efdde9132fa90"
+  integrity sha512-Nx0g7I5ayAYghsLJP4Q1Ch2W9jYYM0FlWWWZocUro8rNxVwuZXGfFd7Rcqi9XDWepSXjg1WByiNJnZza2hIOvQ==
+  dependencies:
+    "@octokit/types" "^6.18.1"
+    deprecation "^2.3.1"
+
+"@octokit/request-error@^2.0.5", "@octokit/request-error@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@octokit/request-error/-/request-error-2.1.0.tgz#9e150357831bfc788d13a4fd4b1913d60c74d677"
+  integrity sha512-1VIvgXxs9WHSjicsRwq8PlR2LR2x6DwsJAaFgzdi0JfJoGSO8mYI/cHJQ+9FbN21aa+DrgNLnwObmyeSC8Rmpg==
+  dependencies:
+    "@octokit/types" "^6.0.3"
+    deprecation "^2.0.0"
+    once "^1.4.0"
+
+"@octokit/request@^5.4.0", "@octokit/request@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@octokit/request/-/request-5.6.0.tgz#6084861b6e4fa21dc40c8e2a739ec5eff597e672"
+  integrity sha512-4cPp/N+NqmaGQwbh3vUsYqokQIzt7VjsgTYVXiwpUP2pxd5YiZB2XuTedbb0SPtv9XS7nzAKjAuQxmY8/aZkiA==
+  dependencies:
+    "@octokit/endpoint" "^6.0.1"
+    "@octokit/request-error" "^2.1.0"
+    "@octokit/types" "^6.16.1"
+    is-plain-object "^5.0.0"
+    node-fetch "^2.6.1"
+    universal-user-agent "^6.0.0"
+
+"@octokit/rest@^17.1.3":
+  version "17.11.2"
+  resolved "https://registry.yarnpkg.com/@octokit/rest/-/rest-17.11.2.tgz#f3dbd46f9f06361c646230fd0ef8598e59183ead"
+  integrity sha512-4jTmn8WossTUaLfNDfXk4fVJgbz5JgZE8eCs4BvIb52lvIH8rpVMD1fgRCrHbSd6LRPE5JFZSfAEtszrOq3ZFQ==
+  dependencies:
+    "@octokit/core" "^2.4.3"
+    "@octokit/plugin-paginate-rest" "^2.2.0"
+    "@octokit/plugin-request-log" "^1.0.0"
+    "@octokit/plugin-rest-endpoint-methods" "3.17.0"
+
+"@octokit/rest@^18.5.6":
+  version "18.6.7"
+  resolved "https://registry.yarnpkg.com/@octokit/rest/-/rest-18.6.7.tgz#89b8ecd13edd9603f00453640d1fb0b4175d4b31"
+  integrity sha512-Kn6WrI2ZvmAztdx+HEaf88RuJn+LK72S8g6OpciE4kbZddAN84fu4fiPGxcEu052WmqKVnA/cnQsbNlrYC6rqQ==
+  dependencies:
+    "@octokit/core" "^3.5.0"
+    "@octokit/plugin-paginate-rest" "^2.6.2"
+    "@octokit/plugin-request-log" "^1.0.2"
+    "@octokit/plugin-rest-endpoint-methods" "5.4.1"
+
+"@octokit/types@^4.1.6":
+  version "4.1.10"
+  resolved "https://registry.yarnpkg.com/@octokit/types/-/types-4.1.10.tgz#e4029c11e2cc1335051775bc1600e7e740e4aca4"
+  integrity sha512-/wbFy1cUIE5eICcg0wTKGXMlKSbaAxEr00qaBXzscLXpqhcwgXeS6P8O0pkysBhRfyjkKjJaYrvR1ExMO5eOXQ==
+  dependencies:
+    "@types/node" ">= 8"
+
+"@octokit/types@^5.0.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@octokit/types/-/types-5.5.0.tgz#e5f06e8db21246ca102aa28444cdb13ae17a139b"
+  integrity sha512-UZ1pErDue6bZNjYOotCNveTXArOMZQFG6hKJfOnGnulVCMcVVi7YIIuuR4WfBhjo7zgpmzn/BkPDnUXtNx+PcQ==
+  dependencies:
+    "@types/node" ">= 8"
+
+"@octokit/types@^6.0.3", "@octokit/types@^6.16.1", "@octokit/types@^6.18.0", "@octokit/types@^6.18.1":
+  version "6.18.1"
+  resolved "https://registry.yarnpkg.com/@octokit/types/-/types-6.18.1.tgz#a6db178536e649fd5d67a7b747754bcc43940be4"
+  integrity sha512-5YsddjO1U+xC8ZYKV8yZYebW55PCc7qiEEeZ+wZRr6qyclynzfyD65KZ5FdtIeP0/cANyFaD7hV69qElf1nMsQ==
+  dependencies:
+    "@octokit/openapi-types" "^8.2.1"
+
+"@types/node@>= 8":
+  version "16.0.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.0.0.tgz#067a6c49dc7a5c2412a505628e26902ae967bf6f"
+  integrity sha512-TmCW5HoZ2o2/z2EYi109jLqIaPIi9y/lc2LmDCWzuCi35bcaQ+OtUh6nwBiFK7SOu25FAU5+YKdqFZUwtqGSdg==
+
 "@types/parse-json@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
@@ -985,7 +1146,7 @@ ansi-colors@4.1.1, ansi-colors@^4.1.1:
   resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-4.1.1.tgz#cbb9ae256bf750af1eab344f229aa27fe94ba348"
   integrity sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==
 
-ansi-escapes@^4.3.0:
+ansi-escapes@^4.2.1, ansi-escapes@^4.3.0:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-4.3.2.tgz#6b2291d1db7d98b6521d5f1efa42d0f3a9feb65e"
   integrity sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==
@@ -1118,6 +1279,11 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
+base64-js@^1.3.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
+  integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
+
 base@^0.11.1:
   version "0.11.2"
   resolved "https://registry.yarnpkg.com/base/-/base-0.11.2.tgz#7bde5ced145b6d551a90db87f83c558b4eb48a8f"
@@ -1131,6 +1297,11 @@ base@^0.11.1:
     mixin-deep "^1.2.0"
     pascalcase "^0.1.1"
 
+before-after-hook@^2.1.0, before-after-hook@^2.2.0:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/before-after-hook/-/before-after-hook-2.2.2.tgz#a6e8ca41028d90ee2c24222f201c90956091613e"
+  integrity sha512-3pZEU3NT5BFUo/AD5ERPWOgQOCZITni6iavr5AUw5AUwQjMlI0kzu5btnyD39AF0gUEsDPwJT+oY1ORBJijPjQ==
+
 binary-extensions@^1.0.0:
   version "1.13.1"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.13.1.tgz#598afe54755b2868a5330d2aff9d4ebb53209b65"
@@ -1140,6 +1311,15 @@ binary-extensions@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
   integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
+
+bl@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/bl/-/bl-4.1.0.tgz#451535264182bec2fbbc83a62ab98cf11d9f7b3a"
+  integrity sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==
+  dependencies:
+    buffer "^5.5.0"
+    inherits "^2.0.4"
+    readable-stream "^3.4.0"
 
 brace-expansion@^1.1.7:
   version "1.1.11"
@@ -1192,6 +1372,14 @@ buffer-from@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
   integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
+
+buffer@^5.5.0:
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.7.1.tgz#ba62e7c13133053582197160851a8f648e99eed0"
+  integrity sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==
+  dependencies:
+    base64-js "^1.3.1"
+    ieee754 "^1.1.13"
 
 cache-base@^1.0.1:
   version "1.0.1"
@@ -1253,6 +1441,16 @@ chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.1:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
+chardet@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
+  integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
+
+checkup@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/checkup/-/checkup-1.3.0.tgz#d3800276fea5d0f247ffc951be78c8b02f8e0d76"
+  integrity sha1-04ACdv6l0PJH/8lRvnjIsC+ODXY=
+
 chokidar@3.5.1:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.1.tgz#ee9ce7bbebd2b79f49f304799d5468e31e14e68a"
@@ -1305,6 +1503,11 @@ cli-cursor@^3.1.0:
   dependencies:
     restore-cursor "^3.1.0"
 
+cli-spinners@^2.5.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-2.6.0.tgz#36c7dc98fb6a9a76bd6238ec3f77e2425627e939"
+  integrity sha512-t+4/y50K/+4xcCRosKkA7W4gTr1MySvLV0q+PxmG7FJ5g+66ChKurYjxBCjHggHH3HA5Hh9cy+lcUGWDqVH+4Q==
+
 cli-truncate@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/cli-truncate/-/cli-truncate-2.1.0.tgz#c39e28bf05edcde5be3b98992a22deed5a2b93c7"
@@ -1312,6 +1515,16 @@ cli-truncate@^2.1.0:
   dependencies:
     slice-ansi "^3.0.0"
     string-width "^4.2.0"
+
+cli-width@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-3.0.0.tgz#a2f48437a2caa9a22436e794bf071ec9e61cedf6"
+  integrity sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==
+
+clipanion@^2.6.2:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/clipanion/-/clipanion-2.6.2.tgz#820e7440812052442455b248f927b187ed732f71"
+  integrity sha512-0tOHJNMF9+4R3qcbBL+4IxLErpaYSYvzs10aXuECDbZdJOuJHdagJMAqvLdeaUQTI/o2uSCDRpet6ywDiKOAYw==
 
 cliui@^6.0.0:
   version "6.0.0"
@@ -1339,6 +1552,11 @@ clone-deep@^4.0.1:
     is-plain-object "^2.0.4"
     kind-of "^6.0.2"
     shallow-clone "^3.0.0"
+
+clone@^1.0.2:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
+  integrity sha1-2jCcwmPfFZlMaIypAheco8fNfH4=
 
 collection-visit@^1.0.0:
   version "1.0.0"
@@ -1445,6 +1663,17 @@ cross-env@^7.0.3:
   dependencies:
     cross-spawn "^7.0.1"
 
+cross-spawn@^6.0.0:
+  version "6.0.5"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
+  integrity sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==
+  dependencies:
+    nice-try "^1.0.4"
+    path-key "^2.0.1"
+    semver "^5.5.0"
+    shebang-command "^1.2.0"
+    which "^1.2.9"
+
 cross-spawn@^7.0.1, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
@@ -1495,6 +1724,13 @@ dedent@^0.7.0:
   resolved "https://registry.yarnpkg.com/dedent/-/dedent-0.7.0.tgz#2495ddbaf6eb874abb0e1be9df22d2e5a544326c"
   integrity sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=
 
+defaults@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/defaults/-/defaults-1.0.3.tgz#c656051e9817d9ff08ed881477f3fe4019f3ef7d"
+  integrity sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=
+  dependencies:
+    clone "^1.0.2"
+
 define-properties@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.3.tgz#cf88da6cbee26fe6db7094f61d870cbd84cee9f1"
@@ -1524,6 +1760,16 @@ define-property@^2.0.2:
     is-descriptor "^1.0.2"
     isobject "^3.0.1"
 
+deprecation@^2.0.0, deprecation@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/deprecation/-/deprecation-2.3.1.tgz#6368cbdb40abf3373b525ac87e4a260c3a700919"
+  integrity sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==
+
+detect-libc@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
+  integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
+
 diff@5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-5.0.0.tgz#7ed6ad76d859d030787ec35855f5b1daf31d852b"
@@ -1545,6 +1791,13 @@ emoji-regex@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
+
+end-of-stream@^1.1.0:
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.4.tgz#5ae64a5f45057baf3626ec14da0ca5e4b2431eb0"
+  integrity sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
+  dependencies:
+    once "^1.4.0"
 
 enquirer@^2.3.6:
   version "2.3.6"
@@ -1579,6 +1832,19 @@ esutils@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
+
+execa@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-1.0.0.tgz#c6236a5bb4df6d6f15e88e7f017798216749ddd8"
+  integrity sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==
+  dependencies:
+    cross-spawn "^6.0.0"
+    get-stream "^4.0.0"
+    is-stream "^1.1.0"
+    npm-run-path "^2.0.0"
+    p-finally "^1.0.0"
+    signal-exit "^3.0.0"
+    strip-eof "^1.0.0"
 
 execa@^5.0.0:
   version "5.1.1"
@@ -1623,6 +1889,15 @@ extend-shallow@^3.0.0, extend-shallow@^3.0.2:
     assign-symbols "^1.0.0"
     is-extendable "^1.0.1"
 
+external-editor@^3.0.3:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-3.1.0.tgz#cb03f740befae03ea4d283caed2741a83f335495"
+  integrity sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==
+  dependencies:
+    chardet "^0.7.0"
+    iconv-lite "^0.4.24"
+    tmp "^0.0.33"
+
 extglob@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/extglob/-/extglob-2.0.4.tgz#ad00fe4dc612a9232e8718711dc5cb5ab0285543"
@@ -1654,6 +1929,18 @@ fastq@^1.6.0:
   integrity sha512-HOnr8Mc60eNYl1gzwp6r5RoUyAn5/glBolUzP/Ez6IFVPMPirxn/9phgL6zhOtaTy7ISwPvQ+wT+hfcRZh/bzw==
   dependencies:
     reusify "^1.0.4"
+
+fdir@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/fdir/-/fdir-5.1.0.tgz#973e4934e6a3666b59ebdfc56f60bb8e9b16acb8"
+  integrity sha512-IgTtZwL52tx2wqWeuGDzXYTnNsEjNLahZpJw30hCQDyVnoHXwY5acNDnjGImTTL1R0z1PCyLw20VAbE5qLic3Q==
+
+figures@^3.0.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/figures/-/figures-3.2.0.tgz#625c18bd293c604dc4a8ddb2febf0c88341746af"
+  integrity sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==
+  dependencies:
+    escape-string-regexp "^1.0.5"
 
 fill-range@^4.0.0:
   version "4.0.0"
@@ -1799,6 +2086,13 @@ get-own-enumerable-property-symbols@^3.0.0:
   resolved "https://registry.yarnpkg.com/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz#b5fde77f22cbe35f390b4e089922c50bce6ef664"
   integrity sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g==
 
+get-stream@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-4.1.0.tgz#c1b255575f3dc21d59bfc79cd3d2b46b1c3a54b5"
+  integrity sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==
+  dependencies:
+    pump "^3.0.0"
+
 get-stream@^6.0.0:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-6.0.1.tgz#a262d8eef67aced57c2852ad6167526a43cbf7b7"
@@ -1935,6 +2229,18 @@ husky@6.0.0:
   resolved "https://registry.yarnpkg.com/husky/-/husky-6.0.0.tgz#810f11869adf51604c32ea577edbc377d7f9319e"
   integrity sha512-SQS2gDTB7tBN486QSoKPKQItZw97BMOd+Kdb6ghfpBc0yXyzrddI0oDV5MkDAbuB4X2mO3/nj60TRMcYxwzZeQ==
 
+iconv-lite@^0.4.24:
+  version "0.4.24"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
+  integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3"
+
+ieee754@^1.1.13:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
+  integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
+
 ignore@^5.1.4:
   version "5.1.8"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
@@ -1961,10 +2267,30 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@^2.0.3, inherits@~2.0.3:
+inherits@2, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
+
+inquirer@^8.1.0:
+  version "8.1.1"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-8.1.1.tgz#7c53d94c6d03011c7bb2a947f0dca3b98246c26a"
+  integrity sha512-hUDjc3vBkh/uk1gPfMAD/7Z188Q8cvTGl0nxwaCdwSbzFh6ZKkZh+s2ozVxbE5G9ZNRyeY0+lgbAIOUFsFf98w==
+  dependencies:
+    ansi-escapes "^4.2.1"
+    chalk "^4.1.1"
+    cli-cursor "^3.1.0"
+    cli-width "^3.0.0"
+    external-editor "^3.0.3"
+    figures "^3.0.0"
+    lodash "^4.17.21"
+    mute-stream "0.0.8"
+    ora "^5.3.0"
+    run-async "^2.4.0"
+    rxjs "^6.6.6"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+    through "^2.3.6"
 
 interpret@^1.0.0:
   version "1.4.0"
@@ -2082,6 +2408,11 @@ is-glob@^4.0.0, is-glob@^4.0.1, is-glob@~4.0.1:
   dependencies:
     is-extglob "^2.1.1"
 
+is-interactive@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-interactive/-/is-interactive-1.0.0.tgz#cea6e6ae5c870a7b0a0004070b7b587e0252912e"
+  integrity sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==
+
 is-number@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-3.0.0.tgz#24fd6201a4782cf50561c810276afc7d12d71195"
@@ -2111,10 +2442,20 @@ is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   dependencies:
     isobject "^3.0.1"
 
+is-plain-object@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-5.0.0.tgz#4427f50ab3429e9025ea7d52e9043a9ef4159344"
+  integrity sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==
+
 is-regexp@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-regexp/-/is-regexp-1.0.0.tgz#fd2d883545c46bac5a633e7b9a09e87fa2cb5069"
   integrity sha1-/S2INUXEa6xaYz57mgnof6LLUGk=
+
+is-stream@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
+  integrity sha1-EtSj3U5o4Lec6428hBc66A2RykQ=
 
 is-stream@^2.0.0:
   version "2.0.0"
@@ -2152,6 +2493,11 @@ isobject@^3.0.0, isobject@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
   integrity sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
+
+jju@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/jju/-/jju-1.4.0.tgz#a3abe2718af241a2b2904f84a625970f389ae32a"
+  integrity sha1-o6vicYryQaKykE+EpiWXDzia4yo=
 
 js-tokens@^4.0.0:
   version "4.0.0"
@@ -2298,6 +2644,11 @@ lodash.debounce@^4.0.8:
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
   integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=
 
+lodash@^4.17.21:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+
 log-symbols@4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-4.0.0.tgz#69b3cc46d20f448eccdb75ea1fa733d9e821c920"
@@ -2322,6 +2673,11 @@ log-update@^4.0.0:
     cli-cursor "^3.1.0"
     slice-ansi "^4.0.0"
     wrap-ansi "^6.2.0"
+
+macos-release@^2.2.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/macos-release/-/macos-release-2.5.0.tgz#067c2c88b5f3fb3c56a375b2ec93826220fa1ff2"
+  integrity sha512-EIgv+QZ9r+814gjJj0Bt5vSLJLzswGmSUbUpbi9AIr/fsN2IWFBl2NucV9PAiek+U1STK468tEkxmVYUtuAN3g==
 
 make-dir@^2.0.0, make-dir@^2.1.0:
   version "2.1.0"
@@ -2379,6 +2735,18 @@ micromatch@^4.0.4:
   dependencies:
     braces "^3.0.1"
     picomatch "^2.2.3"
+
+mime-db@1.48.0:
+  version "1.48.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.48.0.tgz#e35b31045dd7eada3aaad537ed88a33afbef2d1d"
+  integrity sha512-FM3QwxV+TnZYQ2aRqhlKBMHxk10lTbMt3bBkMAp54ddrNeVSfcQYOOKuGuy3Ddrm38I04If834fOUSq1yzslJQ==
+
+mime-types@^2.1.21:
+  version "2.1.31"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.31.tgz#a00d76b74317c61f9c2db2218b8e9f8e9c5c9e6b"
+  integrity sha512-XGZnNzm3QvgKxa8dpzyhFTHmpP3l5YNusmne07VUOXxou9CqUqYa/HBy124RqtVh/O2pECas/MOcsDgpilPOPg==
+  dependencies:
+    mime-db "1.48.0"
 
 mimic-fn@^2.1.0:
   version "2.1.0"
@@ -2451,6 +2819,11 @@ ms@2.1.3:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
+mute-stream@0.0.8:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
+  integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
+
 nanoid@3.1.20:
   version "3.1.20"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.20.tgz#badc263c6b1dcf14b71efaa85f6ab4c1d6cfc788"
@@ -2473,6 +2846,16 @@ nanomatch@^1.2.9:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
+nice-try@^1.0.4:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
+  integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
+
+node-fetch@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
+  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
+
 node-modules-regexp@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz#8d9dbe28964a4ac5712e9131642107c71e90ec40"
@@ -2494,6 +2877,13 @@ normalize-path@^3.0.0, normalize-path@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
   integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
+
+npm-run-path@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"
+  integrity sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=
+  dependencies:
+    path-key "^2.0.0"
 
 npm-run-path@^4.0.1:
   version "4.0.1"
@@ -2540,7 +2930,7 @@ object.pick@^1.3.0:
   dependencies:
     isobject "^3.0.1"
 
-once@^1.3.0:
+once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   integrity sha1-WDsap3WWHUsROsF9nFC6753Xa9E=
@@ -2553,6 +2943,39 @@ onetime@^5.1.0, onetime@^5.1.2:
   integrity sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==
   dependencies:
     mimic-fn "^2.1.0"
+
+ora@^5.3.0:
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/ora/-/ora-5.4.1.tgz#1b2678426af4ac4a509008e5e4ac9e9959db9e18"
+  integrity sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==
+  dependencies:
+    bl "^4.1.0"
+    chalk "^4.1.0"
+    cli-cursor "^3.1.0"
+    cli-spinners "^2.5.0"
+    is-interactive "^1.0.0"
+    is-unicode-supported "^0.1.0"
+    log-symbols "^4.1.0"
+    strip-ansi "^6.0.0"
+    wcwidth "^1.0.1"
+
+os-name@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/os-name/-/os-name-3.1.0.tgz#dec19d966296e1cd62d701a5a66ee1ddeae70801"
+  integrity sha512-h8L+8aNjNcMpo/mAIBPn5PXCM16iyPGjHNWo6U1YO8sJTMHtEtyczI6QJnLoplswm6goopQkqc7OAnjhWcugVg==
+  dependencies:
+    macos-release "^2.2.0"
+    windows-release "^3.1.0"
+
+os-tmpdir@~1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
+  integrity sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
+
+p-finally@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
+  integrity sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=
 
 p-limit@^2.0.0, p-limit@^2.2.0:
   version "2.3.0"
@@ -2638,6 +3061,11 @@ path-is-absolute@^1.0.0:
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
   integrity sha1-F0uSaHNVNP+8es5r9TpanhtcX18=
 
+path-key@^2.0.0, path-key@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
+  integrity sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=
+
 path-key@^3.0.0, path-key@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
@@ -2699,6 +3127,27 @@ process-nextick-args@~2.0.0:
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
   integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
 
+pump@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/pump/-/pump-3.0.0.tgz#b4a2116815bde2f4e1ea602354e8c75565107a64"
+  integrity sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==
+  dependencies:
+    end-of-stream "^1.1.0"
+    once "^1.3.1"
+
+putasset@^5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/putasset/-/putasset-5.0.3.tgz#2fa82a8fc5e2333869df8ffb0e1f8618b1c87b9b"
+  integrity sha512-LGRp0SLOC4PDP/BawMaG3/hw6iKgQPRXcBF7WIzx2XTYwHVk2sS3gpvZqz6bf9GhKMal2phs+DF7J6eIAXEL4w==
+  dependencies:
+    "@octokit/rest" "^17.1.3"
+    checkup "^1.3.0"
+    mime-types "^2.1.21"
+    readjson "^2.0.1"
+    try-catch "^3.0.0"
+    try-to-catch "^3.0.0"
+    yargs-parser "^18.1.1"
+
 queue-microtask@^1.2.2:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
@@ -2724,6 +3173,15 @@ readable-stream@^2.0.2:
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
+readable-stream@^3.4.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
+  integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
+  dependencies:
+    inherits "^2.0.3"
+    string_decoder "^1.1.1"
+    util-deprecate "^1.0.1"
+
 readdirp@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-2.2.1.tgz#0e87622a3325aa33e892285caf8b4e846529a525"
@@ -2746,6 +3204,14 @@ readdirp@~3.6.0:
   integrity sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==
   dependencies:
     picomatch "^2.2.1"
+
+readjson@^2.0.1:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/readjson/-/readjson-2.2.2.tgz#ed940ebdd72b88b383e02db7117402f980158959"
+  integrity sha512-PdeC9tsmLWBiL8vMhJvocq+OezQ3HhsH2HrN7YkhfYcTjQSa/iraB15A7Qvt7Xpr0Yd2rDNt6GbFwVQDg3HcAw==
+  dependencies:
+    jju "^1.4.0"
+    try-catch "^3.0.0"
 
 rechoir@^0.6.2:
   version "0.6.2"
@@ -2871,6 +3337,11 @@ reusify@^1.0.4:
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
 
+run-async@^2.4.0:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.4.1.tgz#8440eccf99ea3e70bd409d49aab88e10c189a455"
+  integrity sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==
+
 run-parallel@^1.1.9:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.2.0.tgz#66d1368da7bdf921eb9d95bd1a9229e7f21a43ee"
@@ -2878,14 +3349,14 @@ run-parallel@^1.1.9:
   dependencies:
     queue-microtask "^1.2.2"
 
-rxjs@^6.6.7:
+rxjs@^6.6.6, rxjs@^6.6.7:
   version "6.6.7"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.7.tgz#90ac018acabf491bf65044235d5863c4dab804c9"
   integrity sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==
   dependencies:
     tslib "^1.9.0"
 
-safe-buffer@^5.1.0:
+safe-buffer@^5.1.0, safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
@@ -2902,6 +3373,11 @@ safe-regex@^1.1.0:
   dependencies:
     ret "~0.1.10"
 
+"safer-buffer@>= 2.1.2 < 3":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
+  integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
+
 semver-compare@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/semver-compare/-/semver-compare-1.0.0.tgz#0dee216a1c941ab37e9efb1788f6afc5ff5537fc"
@@ -2912,7 +3388,7 @@ semver@7.0.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.0.0.tgz#5f3ca35761e47e05b206c6daff2cf814f0316b8e"
   integrity sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==
 
-semver@^5.6.0:
+semver@^5.5.0, semver@^5.6.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
@@ -2951,12 +3427,24 @@ shallow-clone@^3.0.0:
   dependencies:
     kind-of "^6.0.2"
 
+shebang-command@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea"
+  integrity sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=
+  dependencies:
+    shebang-regex "^1.0.0"
+
 shebang-command@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-2.0.0.tgz#ccd0af4f8835fbdc265b82461aaf0c36663f34ea"
   integrity sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==
   dependencies:
     shebang-regex "^3.0.0"
+
+shebang-regex@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
+  integrity sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=
 
 shebang-regex@^3.0.0:
   version "3.0.0"
@@ -2980,7 +3468,7 @@ shx@^0.3.3:
     minimist "^1.2.3"
     shelljs "^0.8.4"
 
-signal-exit@^3.0.2, signal-exit@^3.0.3:
+signal-exit@^3.0.0, signal-exit@^3.0.2, signal-exit@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.3.tgz#a1410c2edd8f077b08b4e253c8eacfcaf057461c"
   integrity sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==
@@ -3119,6 +3607,13 @@ string-width@^4.1.0, string-width@^4.2.0:
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.0"
 
+string_decoder@^1.1.1:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e"
+  integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
+  dependencies:
+    safe-buffer "~5.2.0"
+
 string_decoder@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
@@ -3148,6 +3643,11 @@ strip-ansi@^6.0.0:
   integrity sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==
   dependencies:
     ansi-regex "^5.0.0"
+
+strip-eof@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
+  integrity sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=
 
 strip-final-newline@^2.0.0:
   version "2.0.0"
@@ -3180,7 +3680,7 @@ supports-color@^7.1.0:
   dependencies:
     has-flag "^4.0.0"
 
-through@^2.3.8:
+through@^2.3.6, through@^2.3.8:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
@@ -3189,6 +3689,13 @@ tiny-benchy@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/tiny-benchy/-/tiny-benchy-2.1.0.tgz#f14c2597c54dd4c35ab582824ca4613a60d010d3"
   integrity sha512-84QOWzFrcrswVVfpGp0Bg1uLLKC59EdgT58l57A8J8orCR2wGemCsqsxhpJ7JmbTx8py2915+B9kpcsPDmuTcQ==
+
+tmp@^0.0.33:
+  version "0.0.33"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
+  integrity sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==
+  dependencies:
+    os-tmpdir "~1.0.2"
 
 to-fast-properties@^2.0.0:
   version "2.0.0"
@@ -3227,10 +3734,30 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
 
+toml@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/toml/-/toml-3.0.0.tgz#342160f1af1904ec9d204d03a5d61222d762c5ee"
+  integrity sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==
+
+try-catch@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/try-catch/-/try-catch-3.0.0.tgz#7996d8b89895e2e8ae62cbdbeb4fe17470f8131b"
+  integrity sha512-3uAqUnoemzca1ENvZ72EVimR+E8lqBbzwZ9v4CEbLjkaV3Q+FtdmPUt7jRtoSoTiYjyIMxEkf6YgUpe/voJ1ng==
+
+try-to-catch@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/try-to-catch/-/try-to-catch-3.0.0.tgz#a1903b44d13d5124c54d14a461d22ec1f52ea14b"
+  integrity sha512-eIm6ZXwR35jVF8By/HdbbkcaCDTBI5PpCPkejRKrYp0jyf/DbCCcRhHD7/O9jtFI3ewsqo9WctFEiJTS6i+CQA==
+
 tslib@^1.9.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
+
+tslib@^2.2.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.0.tgz#803b8cdab3e12ba581a4ca41c8839bbb0dacb09e"
+  integrity sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==
 
 type-fest@^0.21.3:
   version "0.21.3"
@@ -3270,6 +3797,18 @@ union-value@^1.0.0:
     is-extendable "^0.1.1"
     set-value "^2.0.1"
 
+universal-user-agent@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/universal-user-agent/-/universal-user-agent-5.0.0.tgz#a3182aa758069bf0e79952570ca757de3579c1d9"
+  integrity sha512-B5TPtzZleXyPrUMKCpEHFmVhMN6EhmJYjG5PQna9s7mXeSqGTLap4OpqLl5FCEFUI3UBmllkETwKf/db66Y54Q==
+  dependencies:
+    os-name "^3.1.0"
+
+universal-user-agent@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/universal-user-agent/-/universal-user-agent-6.0.0.tgz#3381f8503b251c0d9cd21bc1de939ec9df5480ee"
+  integrity sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w==
+
 universalify@^0.1.0:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
@@ -3303,10 +3842,17 @@ use@^3.1.0:
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
   integrity sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==
 
-util-deprecate@~1.0.1:
+util-deprecate@^1.0.1, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
+
+wcwidth@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/wcwidth/-/wcwidth-1.0.1.tgz#f0b0dcf915bc5ff1528afadb2c0e17b532da2fe8"
+  integrity sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=
+  dependencies:
+    defaults "^1.0.3"
 
 which-module@^2.0.0:
   version "2.0.0"
@@ -3320,12 +3866,26 @@ which@2.0.2, which@^2.0.1:
   dependencies:
     isexe "^2.0.0"
 
+which@^1.2.9:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
+  integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
+  dependencies:
+    isexe "^2.0.0"
+
 wide-align@1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.3.tgz#ae074e6bdc0c14a431e804e624549c633b000457"
   integrity sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==
   dependencies:
     string-width "^1.0.2 || 2"
+
+windows-release@^3.1.0:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/windows-release/-/windows-release-3.3.3.tgz#1c10027c7225743eec6b89df160d64c2e0293999"
+  integrity sha512-OSOGH1QYiW5yVor9TtmXKQvt2vjQqbYS+DqmsZw+r7xDwLXEeT3JGW0ZppFmHx4diyXmxt238KFR3N9jzevBRg==
+  dependencies:
+    execa "^1.0.0"
 
 workerpool@6.1.0:
   version "6.1.0"
@@ -3375,7 +3935,7 @@ yargs-parser@20.2.4:
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.4.tgz#b42890f14566796f85ae8e3a25290d205f154a54"
   integrity sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==
 
-yargs-parser@^18.1.2:
+yargs-parser@^18.1.1, yargs-parser@^18.1.2:
   version "18.1.3"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-18.1.3.tgz#be68c4975c6b2abf469236b0c870362fab09a7b0"
   integrity sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==


### PR DESCRIPTION
Reverts parcel-bundler/source-map#85

This appears to have introduced several issues:

On Windows (and possibly some Linux distros also??), the process randomly crashes during Parcel builds. See https://github.com/parcel-bundler/parcel/issues/7578, https://github.com/parcel-bundler/parcel/issues/7590, https://github.com/parcel-bundler/parcel/issues/7598, https://github.com/parcel-bundler/parcel/issues/7603. We believe this to be caused by the source map upgrade, which was released separately from Parcel 2.2.1. Subsequent to this, issues began appearing.

Personally, I have not been able to reproduce it on any of my machines, but @mischnic verified that reverting the sourcemap package to 2.0.0 fixed it for him. I'm not totally sure what the underlying issue is, but it seems to be related to worker threads. Many reports in the above issues confirm that running with `PARCEL_WORKER_BACKEND=process` works around the issue.

cc. @Brooooooklyn. I see you commented on https://github.com/nodejs/node/issues/37673 and on https://github.com/avajs/ava/discussions/2926#discussioncomment-1903791 and subsequently disabled worker threads on the napi tests in https://github.com/napi-rs/napi-rs/pull/1004. This seems related to the error we are seeing. Perhaps the issue is somewhere in napi-rs itself? I'm not sure...

Another issue is that this introduced a dependency on napi into the parcel_sourcemap crate, which is used in other rust projects, not just in node. See https://github.com/parcel-bundler/parcel-css/issues/71.

I'm going to revert this for now while we investigate the above issues.