### PR TITLE
fix: Add constructor to `SourceMap` TS definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -67,6 +67,7 @@ export type GenerateEmptyMapOptions = {
 * A source map to assist in debugging during development
 */
 export default class SourceMap {
+  constructor(projectRoot?: string, buffer?: Buffer);
   static generateEmptyMap(opts: GenerateEmptyMapOptions): SourceMap;
   addEmptyMap(sourceName: string, sourceContent: string, lineOffset?: number): SourceMap;
   addVLQMap(map: VLQMap, lineOffset?: number, columnOffset?: number): SourceMap;


### PR DESCRIPTION
I am passing the project root to `new SourceMap()` (not documented, but it seems to be used in Parcel to ensure paths are relative to the root). Still not 100% clear that I need it, but I figured the type defs should be updated either way!