### PR TITLE
fix: from_json without sources content

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,7 @@
 name: Lint
 on:
   push:
+  pull_request:
   workflow_dispatch:
 
 jobs:
@@ -41,7 +42,7 @@ jobs:
         run: cargo fmt -- --check
 
       - name: Clippy
-        run: cargo clippy
+        run: cargo clippy --all-features
 
       - name: Clear the cargo caches
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,7 @@
 name: test
 on:
   push:
+  pull_request:
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
This PR fixes `SourceMap::from_json` returns an Err when json don't have `sourcesContent` field, since this field are optional for source map.

And changes the CI to able to lint and test when PRs.