### PR TITLE
chore: update github ci workflows

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -9,15 +9,17 @@ jobs:
     name: Performance regression check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Setup node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v6
         with:
-          node-version: 14
+          node-version: 22
           check-latest: true
 
+      - name: Install Yarn
+        run: npm install --global yarn@1
       - name: 'Install dependencies'
-        run: yarn install
+        run: yarn install --frozen-lockfile
       - name: Build code
         run: yarn transpile && yarn build:node-release
       - name: 'Run benchmark'
@@ -25,7 +27,7 @@ jobs:
 
       # Run benchmark action
       - name: Compare benchmark results
-        uses: rhysd/github-action-benchmark@v1.8.1
+        uses: benchmark-action/github-action-benchmark@v1
         with:
           name: Parcel sourcemap benchmark
           tool: 'benchmarkjs'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,30 +10,21 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
 
       - name: Install
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          profile: default
-          override: true
           components: rustfmt, clippy
 
-      # Should use comitted lockfile
-      # - name: Generate Cargo.lock
-      #   uses: actions-rs/cargo@v1
-      #   with:
-      #     command: generate-lockfile
-
       - name: Cache cargo registry
-        uses: actions/cache@v1
+        uses: actions/cache@v5
         with:
           path: ~/.cargo/registry
           key: lint-cargo-registry-trimmed-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Cache cargo index
-        uses: actions/cache@v1
+        uses: actions/cache@v5
         with:
           path: ~/.cargo/git
           key: lint-cargo-index-trimmed-${{ hashFiles('**/Cargo.lock') }}
@@ -48,4 +39,3 @@ jobs:
         run: |
           cargo install cargo-cache --no-default-features --features ci-autoclean
           cargo-cache
-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,22 +19,20 @@ jobs:
     name: build-${{ matrix.target }}
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Install Node.JS
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v6
         with:
-          node-version: 14
+          node-version: 22
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          profile: minimal
-          override: true
+          targets: ${{ matrix.target }}
 
-      - name: Setup rust target
-        run: rustup target add ${{ matrix.target }}
-
-      - uses: bahmutov/npm-install@v1.1.0
+      - name: Install Yarn
+        run: npm install --global yarn@1
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
       - name: Transpile JavaScript
         run: yarn run transpile
       - name: Build node release
@@ -45,7 +43,7 @@ jobs:
         if: ${{ matrix.strip }}
         run: ${{ matrix.strip }} parcel_sourcemap_node/artifacts/*.node
       - name: Upload artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v6
         with:
           name: bindings-${{ matrix.target }}
           path: parcel_sourcemap_node/artifacts/*.node
@@ -54,22 +52,20 @@ jobs:
     name: build-apple-silicon
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Install Node.JS
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v6
         with:
-          node-version: 14
+          node-version: 22
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          profile: minimal
-          override: true
+          targets: aarch64-apple-darwin
 
-      - name: Setup rust target
-        run: rustup target add aarch64-apple-darwin
-
-      - uses: bahmutov/npm-install@v1.1.0
+      - name: Install Yarn
+        run: npm install --global yarn@1
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
       - name: Transpile JavaScript
         run: yarn run transpile
       - name: Build node release
@@ -80,7 +76,7 @@ jobs:
       - name: Strip debug symbols # https://github.com/rust-lang/rust/issues/46034
         run: strip -x parcel_sourcemap_node/artifacts/*.node
       - name: Upload artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v6
         with:
           name: bindings-aarch64-apple-darwin
           path: parcel_sourcemap_node/artifacts/*.node
@@ -92,8 +88,7 @@ jobs:
         include:
           - target: x86_64-unknown-linux-gnu
             strip: strip
-            image: docker.io/centos/nodejs-12-centos7
-            setup: npm install --global yarn@1
+            image: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian
           - target: aarch64-unknown-linux-gnu
             strip: aarch64-linux-gnu-strip
             image: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian-aarch64
@@ -115,26 +110,24 @@ jobs:
       image: ${{ matrix.image }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Install Node.JS
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v6
         with:
-          node-version: 14
+          node-version: 22
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          profile: minimal
-          override: true
+          targets: ${{ matrix.target }}
 
       - name: Setup cross compile toolchain
         if: ${{ matrix.setup }}
         run: ${{ matrix.setup }}
 
-      - name: Setup rust target
-        run: rustup target add ${{ matrix.target }}
-
-      - uses: bahmutov/npm-install@v1.1.0
+      - name: Install Yarn
+        run: npm install --global yarn@1
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
       - name: Transpile JavaScript
         run: yarn run transpile
       - name: Build node release
@@ -145,7 +138,7 @@ jobs:
         if: ${{ matrix.strip }}
         run: ${{ matrix.strip }} parcel_sourcemap_node/artifacts/*.node
       - name: Upload artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v6
         with:
           name: bindings-${{ matrix.target }}
           path: parcel_sourcemap_node/artifacts/*.node
@@ -158,12 +151,19 @@ jobs:
       - build-linux
       - build-apple-silicon
     steps:
-      - uses: actions/checkout@v1
-      - uses: bahmutov/npm-install@v1.1.0
+      - uses: actions/checkout@v6
+      - name: Install Node.JS
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+      - name: Install Yarn
+        run: npm install --global yarn@1
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
       - name: Download artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v8
         with:
           path: parcel_sourcemap_node/artifacts
       - name: Move artifacts
@@ -181,14 +181,17 @@ jobs:
     runs-on: ubuntu-latest
     name: Release Rust crate
     steps:
-      - uses: actions/checkout@v1
-      - uses: bahmutov/npm-install@v1.1.0
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v6
+      - name: Install Node.JS
+        uses: actions/setup-node@v6
         with:
-          toolchain: stable
-          profile: minimal
-          override: true
+          node-version: 22
+      - name: Install Yarn
+        run: npm install --global yarn@1
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
       - run: cargo login ${CRATES_IO_TOKEN}
         env:
           CRATES_IO_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,29 +10,22 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
-        node-version: [12.x, 14.x]
+        node-version: [20.x, 22.x, 24.x]
     name: ${{ matrix.os }}-${{ matrix.node-version }}
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
-      # Caching
-      - name: Cache NPM dependencies
-        uses: actions/cache@v1
-        with:
-          path: node_modules
-          key: node-modules-${{ runner.os }}-${{ hashFiles('yarn.lock') }}-${{ matrix.node-version }}
+        uses: dtolnay/rust-toolchain@stable
 
-      - uses: bahmutov/npm-install@v1.1.0
+      - name: Install Yarn
+        run: npm install --global yarn@1
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
       - name: Transpile JavaScript
         run: yarn run transpile
       - name: Build node release
@@ -46,31 +39,23 @@ jobs:
     name: wasm
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Use Node.js 14.x
-        uses: actions/setup-node@v2
+      - uses: actions/checkout@v6
+      - name: Use Node.js 22.x
+        uses: actions/setup-node@v6
         with:
-          node-version: 14.x
+          node-version: 22.x
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
+        uses: dtolnay/rust-toolchain@stable
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
-      # Caching
-      - name: Cache NPM dependencies
-        uses: actions/cache@v1
-        with:
-          path: node_modules
-          key: node-modules-${{ runner.os }}-${{ hashFiles('yarn.lock') }}-14.x
 
-      - uses: bahmutov/npm-install@v1.1.0
+      - name: Install Yarn
+        run: npm install --global yarn@1
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
       - name: Transpile JavaScript
         run: yarn run transpile
       - name: Build wasm release
         run: yarn run build:wasm-node-release
       - name: Run wasm tests
         run: yarn run test:wasm
-


### PR DESCRIPTION
## Summary

  Updates the GitHub Actions workflow configuration to use current maintained actions and
  runners.

  - Bumps first-party GitHub Actions across test, lint, benchmark, and release workflows.
  - Replaces the unmaintained `actions-rs/toolchain` usage with `dtolnay/rust-toolchain`.
  - Removes the old npm install helper action and installs Yarn explicitly before `yarn
  install --frozen-lockfile`.
  - Moves CI Node versions off EOL 12/14.
  - Leaves JavaScript dependency manifests and lockfiles untouched.

  ## Validation

  - Parsed all workflow YAML files with PyYAML.
  - Ran `git diff --check`.
  - Confirmed no `package.json`, `yarn.lock`, or `Cargo.lock` changes.